### PR TITLE
fix(ui): remove redundant audit buttons + lock checkbox column

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1962,18 +1962,6 @@
       <h1>{$t("title")}</h1>
       <div class="header-actions">
         <button
-          on:click={() => startAudit()}
-          class="button-icon audit-button"
-          class:is-running={auditRunning}
-          disabled={auditRunning}
-          title={auditRunning
-            ? $t("action_audit_running") + ` (${auditDone}/${auditTotal})`
-            : $t("action_audit")}
-          aria-label={$t("action_audit")}
-        >
-          <CheckCircleIcon />
-        </button>
-        <button
           on:click={() => (showSettingsModal = true)}
           class="button-icon settings-button"
           aria-label={$t("settings_title")}
@@ -2505,17 +2493,6 @@
                             aria-label={$t("action_retry")}
                           >
                             <RetryIcon />
-                          </button>
-                        {/if}
-                        <!-- Single audit: immediately check if it is alive (only meaningful for 1fichier) -->
-                        {#if (download.original_url || download.url || "").includes("1fichier.com")}
-                          <button
-                            class="button-icon"
-                            title={$t("action_audit")}
-                            on:click={() => callApi(`/api/downloads/${download.id}/probe`, "POST")}
-                            aria-label={$t("action_audit")}
-                          >
-                            <InfoIcon />
                           </button>
                         {/if}
                       {/if}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1604,7 +1604,11 @@ html[data-theme="light"] {
 
 /* 다중선택 — 행 체크박스 컬럼 + 액션바 */
 .select-col {
+  /* Fixed-width checkbox column so it never stretches with content. */
   width: 44px;
+  min-width: 44px;
+  max-width: 44px;
+  white-space: nowrap;
   text-align: center;
   padding-left: 8px !important;
   padding-right: 8px !important;


### PR DESCRIPTION
Follow-up UI fixes verified in a local preview (Playwright):

- Remove the audit-all button next to the settings gear (top-right). Auditing is done by selecting rows and using "audit selected" in the selection bar.
- Remove the per-row audit/probe button (reused the detail icon and fired a misleading "download request sent" toast).
- Lock the leading checkbox column to a fixed 44px.

Verified by screenshot: header has only the settings button, gauges align, system-metric cards stay inside their cards, period controls are left-aligned, custom checkboxes render, status shows a single label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)