### PR TITLE
fix(audit): per-row loading + in-place updates + ko toast

### DIFF
--- a/backend/api/routes/audit.py
+++ b/backend/api/routes/audit.py
@@ -203,6 +203,10 @@ async def _run_audit(target_ids: List[int]) -> None:
                         "id": req_id,
                         "kind": probe.kind,
                         "summary": probe.summary,
+                        # Include the post-probe fields so the frontend can update
+                        # the row in place (no full list reload needed at the end).
+                        "failure_kind": req.failure_kind,
+                        "next_retry_at": req.next_retry_at.isoformat() if req.next_retry_at else None,
                     },
                 )
             except Exception as e:

--- a/backend/locales/ko.json
+++ b/backend/locales/ko.json
@@ -44,7 +44,7 @@
   "audit_started": "검수 시작 — {total}건 대상",
   "audit_already_running": "이미 검수가 진행 중입니다",
   "audit_no_targets": "검수 대상이 없습니다",
-  "audit_done": "검수 완료 — alive {alive} · dead {dead} · 기타 {other}",
+  "audit_done": "검수 완료 — 정상 {alive} · 삭제됨 {dead} · 기타 {other}",
   "probe_alive_message": "링크 살아있음 — 재시도 가능합니다",
   "probe_dead_message": "원본 파일이 사라진 것으로 확인됨",
   "audit_modal_title": "전체 링크 검수",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -94,6 +94,8 @@
   let auditDone = 0;
   let auditTotal = 0;
   let showAuditModal = false;
+  // Rows currently being audited — used to show a per-row loading spinner.
+  let auditingIds = new Set();
   // Multi-select — checkboxes are always visible in the leading table column.
   let selectedIds = new Set();
   let showBulkDeleteConfirm = false;
@@ -952,7 +954,7 @@
 
       // Batch audit progress — toasts for the start/step/done stages.
       if (message.type === "audit_progress") {
-        const { status, done, total, counts } = message.data;
+        const { status, done, total, counts, item } = message.data;
         if (status === "start") {
           auditTotal = total;
           auditDone = 0;
@@ -961,14 +963,28 @@
         } else if (status === "step") {
           auditDone = done;
           auditTotal = total;
+          // Update the audited row in place and clear its spinner — no full reload.
+          if (item && item.id != null) {
+            queueStateUpdate(() => {
+              downloads = downloads.map((d) =>
+                d.id === item.id
+                  ? { ...d, failure_kind: item.failure_kind, next_retry_at: item.next_retry_at }
+                  : d
+              );
+            });
+            if (auditingIds.has(item.id)) {
+              auditingIds.delete(item.id);
+              auditingIds = new Set(auditingIds);
+            }
+          }
         } else if (status === "done") {
           auditRunning = false;
           auditDone = done;
+          auditingIds = new Set(); // clear any remaining spinners
           const alive = counts?.alive ?? 0;
           const dead = counts?.dead ?? 0;
           const other = total - alive - dead;
           toast.success($t("audit_done", { alive, dead, other }));
-          fetchDownloads(); // Reflect the un-pinned items on screen
         }
       }
     });
@@ -1239,6 +1255,9 @@
   function auditSelected() {
     if (selectedIds.size === 0) return;
     const ids = Array.from(selectedIds);
+    // Mark these rows as auditing so each shows a loading spinner until its
+    // result arrives via the audit_progress 'step' SSE.
+    auditingIds = new Set(ids);
     startAudit({ ids });
   }
 
@@ -2266,7 +2285,12 @@
                         : 'local-status'}"
                       title={getStatusTooltip(download)}
                     >
-                      {#if download.status.toLowerCase() === "waiting" && downloadWaitInfo[download.id] && downloadWaitInfo[download.id].remaining_time > 0}
+                      {#if auditingIds.has(download.id)}
+                        <span class="audit-loading">
+                          <span class="row-audit-spinner"></span>
+                          {$t("action_audit_running")}
+                        </span>
+                      {:else if download.status.toLowerCase() === "waiting" && downloadWaitInfo[download.id] && downloadWaitInfo[download.id].remaining_time > 0}
                         <span class="wait-countdown">
                           {$t("download_waiting_time")} ({formatWaitTime(downloadWaitInfo[download.id].remaining_time)})
                           <span

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -2257,6 +2257,24 @@ label {
   100% { transform: rotate(360deg); }
 }
 
+/* Per-row "auditing" loading indicator (shown in the status cell during audit). */
+.audit-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85em;
+  color: var(--text-secondary);
+}
+.row-audit-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--card-border);
+  border-top-color: var(--primary-color);
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 0.7s linear infinite;
+}
+
 .modal-spinner {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
Per-row audit spinner, in-place row updates from the audit step SSE (no full-screen reload), and fixed mixed-language Korean audit_done toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)