### PR TITLE
fix(ui): shrink oversized checkbox column

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1604,10 +1604,11 @@ html[data-theme="light"] {
 
 /* 다중선택 — 행 체크박스 컬럼 + 액션바 */
 .select-col {
-  /* Fixed-width checkbox column so it never stretches with content. */
-  width: 44px;
-  min-width: 44px;
-  max-width: 44px;
+  /* Override the `table th:nth-child(1) { min-width:150px }` rule (intended for
+     the old first column) now that the checkbox is the first column. */
+  width: 44px !important;
+  min-width: 44px !important;
+  max-width: 44px !important;
   white-space: nowrap;
   text-align: center;
   padding-left: 8px !important;


### PR DESCRIPTION
The checkbox column inherited a stale 150px min-width meant for the old first column; overridden to 44px. Verified in a live preview (150px → 44px). 🤖 Generated with [Claude Code](https://claude.com/claude-code)