### PR TITLE
fix: stop duplicate download tasks + period Apply button overflow (v2.1.1)

### DIFF
--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -320,6 +320,18 @@ class DownloadCore:
     async def start_download_async(self, req: DownloadRequest, db: Session) -> bool:
         """Start an async download"""
         try:
+            # Guard against duplicate tasks for the same download. Retry presses,
+            # auto-start-next, and restart-after-reboot can all re-enter here for an
+            # id that is already running — e.g. a download parked in the pending
+            # state while it waits on a per-site semaphore still holds a live task.
+            # Creating a second task would orphan the first (download_tasks only
+            # tracks one per id), letting both write the same .part file and even
+            # resurrect a deleted row. If a live task exists, this call is a no-op.
+            existing = self.download_tasks.get(req.id)
+            if existing is not None and not existing.done():
+                print(f"[LOG] 이미 실행 중인 다운로드 태스크 존재, 중복 시작 방지: {req.id}")
+                return True
+
             # Stop-then-restart case — if a previous cancel signal is left set,
             # it becomes a bug where the new download's countdown wakes up immediately.
             cancel_signal.clear(req.id)
@@ -1936,7 +1948,15 @@ class DownloadCore:
             print(f"[ERROR] 지연된 자동 시작 실패: {e}")
 
     async def _start_next_pending_download(self):
-        """Auto-start pending downloads (in request-time order)"""
+        """(Re)launch pending downloads that have no live task.
+
+        Each download task queues itself on the correct semaphore (per-site or
+        the shared general/1fichier one), so a freed slot is picked up by an
+        already-parked task automatically. This sweep only needs to relaunch
+        pendings that lost their task (e.g. after a server restart); ones still
+        parked on a semaphore are skipped to avoid duplicate tasks. We therefore
+        do NOT gate on semaphore values here — that old check used the wrong
+        (general) semaphore for per-site hosts and left pendings unstarted."""
         try:
             db = SessionLocal()
 
@@ -1950,29 +1970,15 @@ class DownloadCore:
                 return
 
             started_count = 0
-
             for req in pending_downloads:
-                is_1fichier = "1fichier.com" in req.url
-
-                if is_1fichier and not req.use_proxy:
-                    # 1fichier local download (max 1)
-                    if self.fichier_local_semaphore._value > 0:
-                        success = await self.start_download_async(req, db)
-                        if success:
-                            started_count += 1
-                            print(f"[LOG] 1fichier 로컬 자동 시작: {req.id}")
-                            break  # 1fichier local is limited to 1, so stop once started
-                else:
-                    # General download (includes 1fichier proxy, max 5)
-                    if self.general_download_semaphore._value > 0:
-                        success = await self.start_download_async(req, db)
-                        if success:
-                            started_count += 1
-                            print(f"[LOG] 일반/프록시 다운로드 자동 시작: {req.id}")
-
-                            # Stop once the general download semaphore is fully used
-                            if self.general_download_semaphore._value == 0:
-                                break
+                # Skip ones already parked on a semaphore (live task present).
+                existing = self.download_tasks.get(req.id)
+                if existing is not None and not existing.done():
+                    continue
+                success = await self.start_download_async(req, db)
+                if success:
+                    started_count += 1
+                    print(f"[LOG] 대기 다운로드 자동 시작: {req.id}")
 
             if started_count > 0:
                 print(f"[LOG] 총 {started_count}개 다운로드 자동 시작됨")

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -4,4 +4,4 @@ App version management
 """
 
 # Current app version
-CURRENT_VERSION = "v2.1.0"
+CURRENT_VERSION = "v2.1.1"

--- a/backend/services/download_service.py
+++ b/backend/services/download_service.py
@@ -100,32 +100,19 @@ class DownloadService:
 
             print(f"[LOG] 서버 재시작 후 {len(pending_downloads)}개 대기중인 다운로드 발견")
 
-            # Auto-start via download_core
+            # Auto-start via download_core. Each task parks on its own semaphore
+            # (per-site or the shared general/1fichier one) and enforces the
+            # concurrency limit itself, so we simply launch every pending and let
+            # the semaphores throttle. Gating here on a single semaphore value
+            # would use the wrong limit for per-site hosts and starve pendings.
             from core.download_core import download_core
             started_count = 0
 
             for req in pending_downloads:
-                is_1fichier = "1fichier.com" in req.url
-
-                if is_1fichier and not req.use_proxy:
-                    # 1fichier local download (max 1)
-                    if download_core.fichier_local_semaphore._value > 0:
-                        success = await download_core.start_download_async(req, db)
-                        if success:
-                            started_count += 1
-                            print(f"[LOG] 1fichier 로컬 자동 재시작: {req.id}")
-                            break  # 1fichier local is capped at 1, so stop once started
-                else:
-                    # General download (includes 1fichier via proxy, max 5)
-                    if download_core.general_download_semaphore._value > 0:
-                        success = await download_core.start_download_async(req, db)
-                        if success:
-                            started_count += 1
-                            print(f"[LOG] 일반/프록시 다운로드 자동 재시작: {req.id}")
-
-                            # Stop once the general download semaphore is fully used
-                            if download_core.general_download_semaphore._value == 0:
-                                break
+                success = await download_core.start_download_async(req, db)
+                if success:
+                    started_count += 1
+                    print(f"[LOG] 다운로드 자동 재시작: {req.id}")
 
             print(f"[LOG] 서버 재시작 후 총 {started_count}개 다운로드 자동 시작됨")
 

--- a/backend/tests/test_duplicate_task_guard.py
+++ b/backend/tests/test_duplicate_task_guard.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Regression test for the duplicate download-task guard.
+
+A retry press, the auto-start-next sweep, and restart-after-reboot can all
+re-enter ``start_download_async`` for an id that is already running — e.g. a
+download parked in the ``pending`` state while it waits on a per-site
+semaphore still holds a live task. Before the guard, a second task was created
+and overwrote ``download_tasks[id]``, orphaning the first. Both then wrote the
+same ``.part`` file (clobbering the download) and a deleted row could be
+resurrected by an orphan's commit. The guard makes the re-entrant call a no-op.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.download_core import DownloadCore
+
+
+class _Req:
+    """Minimal stand-in — the guard only reads ``.id`` before returning."""
+
+    def __init__(self, req_id):
+        self.id = req_id
+
+
+@pytest.mark.asyncio
+async def test_start_download_is_noop_when_live_task_exists():
+    dc = DownloadCore()
+    live_task = MagicMock()
+    live_task.done.return_value = False
+    dc.download_tasks[7] = live_task
+
+    result = await dc.start_download_async(_Req(7), MagicMock())
+
+    # Reports success (the caller's intent — "this download is running" — holds)
+    assert result is True
+    # The existing task is untouched: no duplicate/replacement was created.
+    assert dc.download_tasks[7] is live_task
+    assert len(dc.download_tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_finished_task_does_not_trigger_the_guard(monkeypatch):
+    """A previously finished task must not block a fresh (re)start.
+
+    The method's broad ``except`` swallows downstream errors and returns False,
+    so we can't assert via a raised exception. Instead we prove the guard was
+    NOT taken by observing a side effect from the first post-guard line —
+    ``cancel_signal.clear(req.id)`` only runs when execution falls through.
+    """
+    dc = DownloadCore()
+    dc.send_download_update = AsyncMock()  # avoid real SSE in the except path
+    finished_task = MagicMock()
+    finished_task.done.return_value = True
+    dc.download_tasks[9] = finished_task
+
+    cleared = {}
+    monkeypatch.setattr(
+        "core.download_core.cancel_signal.clear",
+        lambda req_id: cleared.setdefault("id", req_id),
+        raising=True,
+    )
+
+    # ``req.url`` is touched right after the guard; raising there halts the
+    # pipeline cheaply (the error is caught internally and returns False).
+    class _RaisingReq:
+        id = 9
+
+        @property
+        def url(self):
+            raise RuntimeError("reached post-guard logic")
+
+    result = await dc.start_download_async(_RaisingReq(), MagicMock())
+
+    assert cleared.get("id") == 9, "guard wrongly short-circuited a finished task"
+    assert result is False

--- a/frontend/src/lib/HistoryPeriodControls.svelte
+++ b/frontend/src/lib/HistoryPeriodControls.svelte
@@ -76,10 +76,10 @@
         bind:value={endDate}
         aria-label={$t("history_period_end")}
       />
-      <button type="button" class="period-apply" on:click={applyCustom}>
-        {$t("history_period_apply")}
-      </button>
     </div>
+    <button type="button" class="period-apply" on:click={applyCustom}>
+      {$t("history_period_apply")}
+    </button>
   {/if}
 </div>
 
@@ -233,6 +233,10 @@
       min-width: 0;
       font-size: 0.82rem;
       padding: 0.4rem 0.3rem;
+    }
+    .period-apply {
+      flex: 1 1 100%;
+      width: 100%;
     }
   }
 </style>

--- a/standalone/version_info.txt
+++ b/standalone/version_info.txt
@@ -2,8 +2,8 @@
 #
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 1, 0, 0),
-    prodvers=(2, 1, 0, 0),
+    filevers=(2, 1, 1, 0),
+    prodvers=(2, 1, 1, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -18,12 +18,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'jshsakura'),
         StringStruct(u'FileDescription', u'OC Proxy Downloader'),
-        StringStruct(u'FileVersion', u'2.1.0'),
+        StringStruct(u'FileVersion', u'2.1.1'),
         StringStruct(u'InternalName', u'oc-proxy-downloader'),
         StringStruct(u'LegalCopyright', u'Copyright (c) 2025 jshsakura'),
         StringStruct(u'OriginalFilename', u'oc-proxy-downloader.exe'),
         StringStruct(u'ProductName', u'OC Proxy Downloader'),
-        StringStruct(u'ProductVersion', u'2.1.0')])
+        StringStruct(u'ProductVersion', u'2.1.1')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]


### PR DESCRIPTION
## Summary

Fixes a regression introduced with the per-site download concurrency limits, plus a UI overflow on the history period control.

### 1. Duplicate download tasks for the same id (root cause of three symptoms)
Retry presses, the auto-start-next sweep, and restart-after-reboot could all re-enter `start_download_async` for an id whose task was **still alive** (e.g. parked on a per-site semaphore in the `pending` state). Because `download_tasks` tracks only one task per id, a second task **orphaned** the first. The orphans caused:

- **Stuck "대기중" that floods in at once** — multiple queued duplicates for the same file all acquire the semaphore when a slot frees.
- **Same file repeatedly overwritten** — duplicate tasks share one `.part` path and clobber each other.
- **Selected-delete appears to fail** — `stop` only cancels the one tracked task; orphans survive and an orphan's commit resurrects the deleted row.

Changes:
- `start_download_async`: no-op (`return True`) when a live task already exists for the id.
- `_start_next_pending_download` / `_start_pending_downloads_after_restart`: skip pendings that still hold a live task, and stop gating on a single semaphore value (the old `general_download_semaphore` check was wrong for per-site hosts and could starve pendings). Each task queues itself on the correct semaphore.

### 2. Period "적용" (Apply) button vertical overflow
The Apply button (34px) was nested inside the date-range pill (also 34px + 1px border), filling it top-to-bottom. Moved it out to a sibling control on the shared baseline (as the source comment intended); full-width on mobile.

## Test plan
- [x] Added `backend/tests/test_duplicate_task_guard.py` (dedup guard regression).
- [x] Full backend suite: **439 passed, 1 skipped, 1 xpassed**.
- [x] Frontend `npm run build` succeeds.
- [ ] Manual: retry a host at its per-site limit → no duplicate rows; deleting selected stuck rows works; period Apply button aligned on desktop + full-width on mobile.