### PR TITLE
fix: cap special-hoster parsing to stop infinite parsing hang (v2.1.2)

### DIFF
--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -79,6 +79,15 @@ SSE_CALLBACK_TIMEOUT_SEC = 1.0
 # Wait limit for a download task to respond to cancellation.
 TASK_CANCEL_TIMEOUT_SEC = 1.0
 
+# Hard cap on resolving a special-hoster page (MegaUp/DataNodes/etc.) to its
+# final link. The underlying calls (cloudscraper + up to two FlareSolverr
+# solves + a requests fetch) are each individually bounded, but if any of them
+# stalls — e.g. FlareSolverr unreachable/co-located behind a hung socket, or a
+# server that sends headers then trickles the body — the download can sit in
+# the "parsing" state indefinitely and never release its per-site semaphore.
+# Exceeding this cap fails the download with a clear message and frees the slot.
+SPECIAL_HOSTER_PARSE_TIMEOUT_SEC = 300  # 5 minutes
+
 
 def _build_proxy_dict(proxy_addr: Optional[str]) -> Optional[Dict[str, str]]:
     """Convert ``proxy_addr`` (e.g. ``1.2.3.4:8080``) into the proxies dict that
@@ -1686,10 +1695,23 @@ class DownloadCore:
 
         try:
             loop = asyncio.get_event_loop()
-            parse_result = await loop.run_in_executor(
-                None,
-                lambda: parse_special_hoster_sync(req.url, req.password),
-            )
+            try:
+                parse_result = await asyncio.wait_for(
+                    loop.run_in_executor(
+                        None,
+                        lambda: parse_special_hoster_sync(req.url, req.password),
+                    ),
+                    timeout=SPECIAL_HOSTER_PARSE_TIMEOUT_SEC,
+                )
+            except asyncio.TimeoutError:
+                # The executor thread may linger until its own bounded calls
+                # finish, but the task fails now so the semaphore slot is freed
+                # and the row leaves the "parsing" state instead of hanging.
+                minutes = SPECIAL_HOSTER_PARSE_TIMEOUT_SEC // 60
+                raise Exception(
+                    f"호스팅 페이지 파싱 시간 초과 ({minutes}분). "
+                    "FlareSolverr 미응답 또는 호스트 차단 가능."
+                )
 
             file_info = parse_result.get("file_info") or {}
             if _should_replace_file_name(req.file_name, file_info.get("name")):

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -4,4 +4,4 @@ App version management
 """
 
 # Current app version
-CURRENT_VERSION = "v2.1.1"
+CURRENT_VERSION = "v2.1.2"

--- a/backend/tests/test_special_hoster_parse_timeout.py
+++ b/backend/tests/test_special_hoster_parse_timeout.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Regression test: special-hoster parsing must not hang forever.
+
+MegaUp/DataNodes resolution chains several network calls. If one stalls, the
+download used to sit in the ``parsing`` state indefinitely and never release
+its per-site semaphore. A hard cap now fails the download instead. This test
+makes the underlying parse block longer than a shrunk cap and asserts the task
+fails promptly rather than waiting on the hung call.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import core.download_core as dc_mod
+from core.download_core import DownloadCore
+from core.models import StatusEnum
+
+
+class _Req:
+    def __init__(self):
+        self.id = 1
+        self.url = "https://megaup.net/abc/file.rar"
+        self.password = None
+        self.status = StatusEnum.pending
+        self.finished_at = None
+
+
+class _Verdict:
+    user_message = "timeout"
+    kind = "unknown"
+    next_retry_at = None
+    attempt_count = 1
+
+
+@pytest.mark.asyncio
+async def test_parsing_times_out_instead_of_hanging(monkeypatch):
+    dc = DownloadCore()
+    dc.send_download_update = AsyncMock()
+
+    # Shrink the cap and make the parse block well past it.
+    monkeypatch.setattr(dc_mod, "SPECIAL_HOSTER_PARSE_TIMEOUT_SEC", 0.2, raising=True)
+    monkeypatch.setattr(
+        dc_mod, "parse_special_hoster_sync",
+        lambda *a, **k: time.sleep(1.5),  # hangs (returns None after the cap)
+        raising=True,
+    )
+    monkeypatch.setattr(
+        dc_mod, "apply_failure_to_request",
+        lambda *a, **k: _Verdict(), raising=True,
+    )
+
+    req = _Req()
+    started = time.monotonic()
+    await dc._download_special_hoster_async(req, MagicMock())
+    elapsed = time.monotonic() - started
+
+    # Failed (not stuck in parsing), and returned at the cap — not after the hang.
+    assert req.status == StatusEnum.failed
+    assert elapsed < 1.0, f"did not time out promptly (took {elapsed:.2f}s)"
+    dc.send_download_update.assert_awaited()

--- a/standalone/version_info.txt
+++ b/standalone/version_info.txt
@@ -2,8 +2,8 @@
 #
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 1, 1, 0),
-    prodvers=(2, 1, 1, 0),
+    filevers=(2, 1, 2, 0),
+    prodvers=(2, 1, 2, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -18,12 +18,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'jshsakura'),
         StringStruct(u'FileDescription', u'OC Proxy Downloader'),
-        StringStruct(u'FileVersion', u'2.1.1'),
+        StringStruct(u'FileVersion', u'2.1.2'),
         StringStruct(u'InternalName', u'oc-proxy-downloader'),
         StringStruct(u'LegalCopyright', u'Copyright (c) 2025 jshsakura'),
         StringStruct(u'OriginalFilename', u'oc-proxy-downloader.exe'),
         StringStruct(u'ProductName', u'OC Proxy Downloader'),
-        StringStruct(u'ProductVersion', u'2.1.1')])
+        StringStruct(u'ProductVersion', u'2.1.2')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]


### PR DESCRIPTION
## Summary
Stops MegaUp/DataNodes downloads from sitting in the **parsing** state forever.

Resolving a special-hoster page to its final link chains cloudscraper → up to two FlareSolverr solves → a `requests` fetch. Each call is individually bounded, but if any stalls (FlareSolverr unreachable, a server that sends headers then trickles the body, etc.) the download:
- stays in `parsing` indefinitely,
- never releases its per-site semaphore (blocking other downloads of that host),
- can't be cleanly stopped/deleted (the work runs in an executor thread).

## Change
- Wrap `parse_special_hoster_sync` in `asyncio.wait_for(SPECIAL_HOSTER_PARSE_TIMEOUT_SEC=300s)`.
- On timeout: fail the download with a clear Korean message ("호스팅 페이지 파싱 시간 초과 (5분). FlareSolverr 미응답 또는 호스트 차단 가능.") and free the semaphore slot. The lingering executor thread completes its own bounded calls in the background.
- Mirrors the existing 1fichier "cap free-download wait" pattern.

## Test plan
- [x] Added `backend/tests/test_special_hoster_parse_timeout.py` — blocks the parse past a shrunk cap, asserts the download fails promptly (no hang).
- [x] Full backend suite: **440 passed, 1 skipped, 1 xpassed**.

Note: version bumped to v2.1.2 — the repo's auto-tag workflow will create the `2.1.2` tag + release on merge (no manual tag this time).