### PR TITLE
chore(deploy): bundle FlareSolverr as a compose sidecar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - PUID=1000  # 시놀로지 사용자 ID (ls -la downloads 로 확인)
       - PGID=1000  # 시놀로지 그룹 ID (ls -la downloads 로 확인)
 
+      # FlareSolverr 연동 (아래 flaresolverr 서비스로 자동 연결)
+      # MegaUp/DataNodes 등 Cloudflare 보호 호스트의 파싱/다운로드에 필요.
+      # 별도 컨테이너이므로 localhost 가 아니라 서비스 이름으로 가리켜야 함.
+      - FLARESOLVERR_URL=http://flaresolverr:8191
+
       # 보안 설정 (선택사항 - 미설정 시 인증 없음)
       # - AUTH_USERNAME=admin
       # - AUTH_PASSWORD=secure123
@@ -20,10 +25,26 @@ services:
       - ./backend/config:/config     # 설정 파일 및 데이터베이스
     ports:
       - "8000:8000"
+    depends_on:
+      - flaresolverr
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/settings"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s 
+      start_period: 10s
+
+  # Cloudflare 챌린지 우회용 헤드리스 브라우저.
+  # 앱과 같은 네트워크/호스트에 두어야 cf_clearance 쿠키의 egress IP 가 일치함.
+  # amd64/arm64 지원. 8191 포트는 앱만 쓰면 되므로 호스트로 노출하지 않음
+  # (디버깅이 필요하면 아래 ports 주석을 해제).
+  flaresolverr:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    container_name: flaresolverr
+    environment:
+      - TZ=Asia/Seoul
+      - LOG_LEVEL=info
+    # ports:
+    #   - "8191:8191"
+    restart: unless-stopped


### PR DESCRIPTION
## Why
MegaUp/DataNodes are Cloudflare-protected. The app resolves their final download link (and retries 403s) via FlareSolverr, but it only discovers FlareSolverr through the `FLARESOLVERR_URL` env var (default `http://localhost:8191`, no settings UI). When FlareSolverr runs as a *separate* container, `localhost:8191` points at the app itself → unreachable → 403 / parse failures.

## Change
`docker-compose.yml`:
- Add a `flaresolverr` service (`ghcr.io/flaresolverr/flaresolverr:latest`, amd64/arm64).
- Wire the app with `FLARESOLVERR_URL=http://flaresolverr:8191` and `depends_on: flaresolverr`.
- Keep 8191 internal (not host-published; comment shows how to expose for debugging).

Co-locating FlareSolverr also keeps the `cf_clearance` cookie's egress IP aligned with the download path, which is required for the cookie to be accepted.

## Notes / caveats
- This only helps when Cloudflare **challenges** the IP. If MegaUp **hard-blocks** the datacenter IP outright, the cookie won't help — that needs a proxy-routed download (separate change) or downloading from a non-blocked network.
- FlareSolverr is headless Chrome (~250–700MB RAM). Users on tight hardware can drop the service.
- README could later document the FlareSolverr env; out of scope here.

## Test plan
- [x] `docker compose config` validates.