### PR TITLE
fix(ui): equal-height proxy/local gauge status rows

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -3383,11 +3383,14 @@ table th:first-child {
   flex: 1;
   width: 100%;
 }
-/* 안쪽 status pill 도 카드 하단까지 가득 차도록 flex-grow → 두 카드 높이 일치 */
+/* 하단 status pill: 40px 는 너무 높아 작게 '고정'. margin-top:auto 로 카드 바닥에
+ * 붙여, 좌/우 헤더 높이가 달라도 두 pill 이 항상 같은 높이로 하단 정렬됨. */
 .live-pane :global(.proxy-status),
 .live-pane :global(.local-status) {
-  flex: 1;
-  min-height: 38px;
+  flex: 0 0 auto;
+  height: 34px;
+  min-height: 34px;
+  margin-top: auto;
   align-items: center;
 }
 @media (max-width: 759px) {

--- a/frontend/src/lib/ProxyGauge.svelte
+++ b/frontend/src/lib/ProxyGauge.svelte
@@ -326,6 +326,17 @@
     min-height: 40px;
   }
 
+  /* The same .status-text class is reused for the bottom status label span.
+   * Stop the header's 40px min-height from leaking onto it (which inflated the
+   * proxy status row vs the local one). Match LocalGauge's inner-label style. */
+  .proxy-status .status-text {
+    min-height: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .status-left {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Problem
The proxy and local live-gauge cards showed **different status-row heights** at the bottom.

## Cause
`ProxyGauge.svelte` reuses the `.status-text` class for *both* the header `div` and the bottom status-label `span`. The header rule's `min-height: 40px` leaked onto the label span, inflating the proxy status row. LocalGauge styles its inner label separately, so it didn't have this.

## Fix
- **ProxyGauge:** scope `.proxy-status .status-text` to reset the leaked `min-height` (mirrors LocalGauge's inner-label style).
- **app.css:** both status pills now use a **fixed 34px height** (40px was too tall) with `margin-top: auto`, pinning them to the card bottom. The rows stay equal height and bottom-aligned even if the two headers differ.

## Test plan
- [x] `npm run build` succeeds.
- [ ] Visual: proxy ("대기 중..") and local ("다운로드중") status rows are the same height and bottom-aligned on desktop + mobile.

Note: CSS only, compiled into the image. `docker-compose.yml` pulls `:latest`, which rebuilds on merge to main — `docker compose pull` picks it up (no version bump).