### PR TITLE
fix(ui): equal-height proxy/local gauge headers

### DIFF
--- a/frontend/src/lib/LocalGauge.svelte
+++ b/frontend/src/lib/LocalGauge.svelte
@@ -152,8 +152,11 @@
   }
 
   .local-info {
-    /* Match ProxyGauge header row height so the two cards line up */
+    /* Fixed header height — must equal ProxyGauge's header so the two cards line up */
+    flex: 0 0 40px;
+    height: 40px;
     min-height: 40px;
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/frontend/src/lib/ProxyGauge.svelte
+++ b/frontend/src/lib/ProxyGauge.svelte
@@ -326,6 +326,15 @@
     min-height: 40px;
   }
 
+  /* Header row only (direct child) — lock to a fixed height so it lines up with
+   * LocalGauge's header exactly. Does NOT match the inner .proxy-status label
+   * (not a direct child of .proxy-gauge). */
+  .proxy-gauge > .status-text {
+    flex: 0 0 40px;
+    height: 40px;
+    box-sizing: border-box;
+  }
+
   /* The same .status-text class is reused for the bottom status label span.
    * Stop the header's 40px min-height from leaking onto it (which inflated the
    * proxy status row vs the local one). Match LocalGauge's inner-label style. */


### PR DESCRIPTION
Follow-up to the status-row fix. The two gauge **headers** still rendered at slightly different heights. Lock both to a fixed 40px (`box-sizing: border-box; flex: 0 0 40px`).

- ProxyGauge: target only the header via `.proxy-gauge > .status-text` (direct child) so the reused `.status-text` label span in the bottom row is untouched.
- LocalGauge: `.local-info` fixed to 40px.

CSS only; `:latest` rebuilds on merge. `npm run build` passes.