### PR TITLE
fix(ui): show 1fichier id instead of '없음' for unfetched filenames

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1456,6 +1456,16 @@
     return !name || /^1fichier:/i.test(name.trim());
   }
 
+  // What to actually show in the filename cell. A `1fichier:<id>` placeholder
+  // means the real name hasn't been fetched yet (not that the file is missing),
+  // so surface the file id as an identifier instead of a misleading "없음".
+  function displayFileName(name) {
+    if (!name) return $t("file_name_na");
+    const m = name.trim().match(/^1fichier:(.+)$/i);
+    if (m) return m[1];
+    return name;
+  }
+
   function getStatusTooltip(download) {
     const proxyInfo = downloadProxyInfo[download.id];
 
@@ -2277,10 +2287,10 @@
                   </td>
                   <td
                     class="filename"
-                    title={!isPlaceholderName(download.filename) ? download.filename : $t("file_name_na")}
+                    title={displayFileName(download.filename)}
                   >
                     <span class="filename-text"
-                      >{!isPlaceholderName(download.filename) ? download.filename : $t("file_name_na")}</span
+                      >{displayFileName(download.filename)}</span
                     >
                   </td>
                   <td class="center-align">


### PR DESCRIPTION
## Point
A row showing **없음** for a 1fichier link doesn't mean the file is nameless — it means the **real filename hasn't been fetched yet**.

## Why it happened
- A `https://1fichier.com/?<id>` link has no filename in the URL, so it's stamped with the placeholder `1fichier:<id>` at add time.
- The real name is filled later by page parsing (`extract_file_info_simple`) or the download's `Content-Disposition`.
- The list rendered any placeholder (`isPlaceholderName`) as `file_name_na` = **없음**, which reads as 'the file has no name'.

## Fix
Render the **1fichier file id** for placeholder rows instead of '없음', so it's clearly an identifier with the name still pending — not an absent file.

## Notes
- Backend already resolves the name from Content-Disposition on download and *fails* the download if it truly can't determine a name, so '없음' was mostly appearing on **pending** rows (name not parsed yet).
- If a **completed** download still shows only the id, that means `extract_file_info_simple` couldn't parse the name from the 1fichier page (likely a page-structure change) — that needs a sample `parse_debug_get.html` to fix the selector.

`npm run build` passes. CSS/JS only; `:latest` rebuilds on merge.