### PR TITLE
fix(ui): distinguish filename fetch state (queued/fetching/failed/unresolved)

### DIFF
--- a/backend/locales/ar.json
+++ b/backend/locales/ar.json
@@ -425,5 +425,9 @@
   "folder_select_error": "حدث خطأ أثناء تحديد المجلد",
   "folder_select": "تحديد مجلد",
   "proxy_page_range": "عرض {start}-{end}",
-  "settings_saved": "تم حفظ الإعدادات."
+  "settings_saved": "تم حفظ الإعدادات.",
+  "file_name_queued": "الاسم قيد الانتظار",
+  "file_name_fetching": "جارٍ جلب الاسم…",
+  "file_name_failed": "الاسم غير متوفر",
+  "file_name_unresolved": "لم يُعثر على الاسم"
 }

--- a/backend/locales/de.json
+++ b/backend/locales/de.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Beim Auswählen des Ordners ist ein Fehler aufgetreten",
   "folder_select": "Ordner auswählen",
   "proxy_page_range": "{start}-{end} angezeigt",
-  "settings_saved": "Einstellungen gespeichert."
+  "settings_saved": "Einstellungen gespeichert.",
+  "file_name_queued": "Name ausstehend",
+  "file_name_fetching": "Name wird abgerufen…",
+  "file_name_failed": "Name nicht verfügbar",
+  "file_name_unresolved": "Name nicht gefunden"
 }

--- a/backend/locales/en.json
+++ b/backend/locales/en.json
@@ -425,5 +425,9 @@
   "folder_select_error": "An error occurred while selecting the folder",
   "folder_select": "Select Folder",
   "proxy_page_range": "{start}-{end} shown",
-  "settings_saved": "Settings saved."
+  "settings_saved": "Settings saved.",
+  "file_name_queued": "Name pending",
+  "file_name_fetching": "Fetching name…",
+  "file_name_failed": "Name unavailable",
+  "file_name_unresolved": "Name not found"
 }

--- a/backend/locales/es.json
+++ b/backend/locales/es.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Se produjo un error al seleccionar la carpeta",
   "folder_select": "Seleccionar carpeta",
   "proxy_page_range": "{start}-{end} mostrados",
-  "settings_saved": "Ajustes guardados."
+  "settings_saved": "Ajustes guardados.",
+  "file_name_queued": "Nombre pendiente",
+  "file_name_fetching": "Obteniendo nombre…",
+  "file_name_failed": "Nombre no disponible",
+  "file_name_unresolved": "Nombre no encontrado"
 }

--- a/backend/locales/fr.json
+++ b/backend/locales/fr.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Une erreur s'est produite lors de la sélection du dossier",
   "folder_select": "Sélectionner un dossier",
   "proxy_page_range": "{start}-{end} affichés",
-  "settings_saved": "Paramètres enregistrés."
+  "settings_saved": "Paramètres enregistrés.",
+  "file_name_queued": "Nom en attente",
+  "file_name_fetching": "Récupération du nom…",
+  "file_name_failed": "Nom indisponible",
+  "file_name_unresolved": "Nom introuvable"
 }

--- a/backend/locales/id.json
+++ b/backend/locales/id.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Terjadi kesalahan saat memilih folder",
   "folder_select": "Pilih folder",
   "proxy_page_range": "Menampilkan {start}-{end}",
-  "settings_saved": "Pengaturan disimpan."
+  "settings_saved": "Pengaturan disimpan.",
+  "file_name_queued": "Nama menunggu",
+  "file_name_fetching": "Mengambil nama…",
+  "file_name_failed": "Nama tidak tersedia",
+  "file_name_unresolved": "Nama tidak ditemukan"
 }

--- a/backend/locales/it.json
+++ b/backend/locales/it.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Si è verificato un errore durante la selezione della cartella",
   "folder_select": "Seleziona cartella",
   "proxy_page_range": "{start}-{end} mostrati",
-  "settings_saved": "Impostazioni salvate."
+  "settings_saved": "Impostazioni salvate.",
+  "file_name_queued": "Nome in attesa",
+  "file_name_fetching": "Recupero nome…",
+  "file_name_failed": "Nome non disponibile",
+  "file_name_unresolved": "Nome non trovato"
 }

--- a/backend/locales/ja.json
+++ b/backend/locales/ja.json
@@ -425,5 +425,9 @@
   "folder_select_error": "フォルダの選択中にエラーが発生しました",
   "folder_select": "フォルダを選択",
   "proxy_page_range": "{start}-{end} を表示",
-  "settings_saved": "設定を保存しました。"
+  "settings_saved": "設定を保存しました。",
+  "file_name_queued": "ファイル名待機中",
+  "file_name_fetching": "ファイル名取得中…",
+  "file_name_failed": "ファイル名取得失敗",
+  "file_name_unresolved": "ファイル名不明"
 }

--- a/backend/locales/ko.json
+++ b/backend/locales/ko.json
@@ -425,5 +425,9 @@
   "folder_select_error": "폴더 선택 중 오류가 발생했습니다",
   "folder_select": "폴더 선택",
   "proxy_page_range": "{start}~{end} 표시",
-  "settings_saved": "설정이 저장되었습니다."
+  "settings_saved": "설정이 저장되었습니다.",
+  "file_name_queued": "파일명 대기 중",
+  "file_name_fetching": "파일명 가져오는 중…",
+  "file_name_failed": "파일명 못 가져옴",
+  "file_name_unresolved": "파일명 확인 불가"
 }

--- a/backend/locales/nl.json
+++ b/backend/locales/nl.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Er is een fout opgetreden bij het selecteren van de map",
   "folder_select": "Map selecteren",
   "proxy_page_range": "{start}-{end} weergegeven",
-  "settings_saved": "Instellingen opgeslagen."
+  "settings_saved": "Instellingen opgeslagen.",
+  "file_name_queued": "Naam in afwachting",
+  "file_name_fetching": "Naam ophalen…",
+  "file_name_failed": "Naam niet beschikbaar",
+  "file_name_unresolved": "Naam niet gevonden"
 }

--- a/backend/locales/pl.json
+++ b/backend/locales/pl.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Wystąpił błąd podczas wybierania folderu",
   "folder_select": "Wybierz folder",
   "proxy_page_range": "Wyświetlono {start}-{end}",
-  "settings_saved": "Ustawienia zapisane."
+  "settings_saved": "Ustawienia zapisane.",
+  "file_name_queued": "Nazwa oczekuje",
+  "file_name_fetching": "Pobieranie nazwy…",
+  "file_name_failed": "Nazwa niedostępna",
+  "file_name_unresolved": "Nazwa nieznaleziona"
 }

--- a/backend/locales/pt-BR.json
+++ b/backend/locales/pt-BR.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Ocorreu um erro ao selecionar a pasta",
   "folder_select": "Selecionar pasta",
   "proxy_page_range": "{start}-{end} exibidos",
-  "settings_saved": "Configurações salvas."
+  "settings_saved": "Configurações salvas.",
+  "file_name_queued": "Nome pendente",
+  "file_name_fetching": "Obtendo nome…",
+  "file_name_failed": "Nome indisponível",
+  "file_name_unresolved": "Nome não encontrado"
 }

--- a/backend/locales/ru.json
+++ b/backend/locales/ru.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Произошла ошибка при выборе папки",
   "folder_select": "Выбрать папку",
   "proxy_page_range": "Показано {start}-{end}",
-  "settings_saved": "Настройки сохранены."
+  "settings_saved": "Настройки сохранены.",
+  "file_name_queued": "Имя ожидается",
+  "file_name_fetching": "Получение имени…",
+  "file_name_failed": "Имя недоступно",
+  "file_name_unresolved": "Имя не найдено"
 }

--- a/backend/locales/th.json
+++ b/backend/locales/th.json
@@ -425,5 +425,9 @@
   "folder_select_error": "เกิดข้อผิดพลาดขณะเลือกโฟลเดอร์",
   "folder_select": "เลือกโฟลเดอร์",
   "proxy_page_range": "แสดง {start}-{end}",
-  "settings_saved": "บันทึกการตั้งค่าแล้ว"
+  "settings_saved": "บันทึกการตั้งค่าแล้ว",
+  "file_name_queued": "รอชื่อไฟล์",
+  "file_name_fetching": "กำลังดึงชื่อ…",
+  "file_name_failed": "ไม่มีชื่อไฟล์",
+  "file_name_unresolved": "ไม่พบชื่อไฟล์"
 }

--- a/backend/locales/tr.json
+++ b/backend/locales/tr.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Klasör seçilirken bir hata oluştu",
   "folder_select": "Klasör seç",
   "proxy_page_range": "{start}-{end} gösteriliyor",
-  "settings_saved": "Ayarlar kaydedildi."
+  "settings_saved": "Ayarlar kaydedildi.",
+  "file_name_queued": "Ad bekleniyor",
+  "file_name_fetching": "Ad alınıyor…",
+  "file_name_failed": "Ad kullanılamıyor",
+  "file_name_unresolved": "Ad bulunamadı"
 }

--- a/backend/locales/vi.json
+++ b/backend/locales/vi.json
@@ -425,5 +425,9 @@
   "folder_select_error": "Đã xảy ra lỗi khi chọn thư mục",
   "folder_select": "Chọn thư mục",
   "proxy_page_range": "Hiển thị {start}-{end}",
-  "settings_saved": "Đã lưu cài đặt."
+  "settings_saved": "Đã lưu cài đặt.",
+  "file_name_queued": "Đang chờ tên",
+  "file_name_fetching": "Đang lấy tên…",
+  "file_name_failed": "Không có tên",
+  "file_name_unresolved": "Không tìm thấy tên"
 }

--- a/backend/locales/zh-CN.json
+++ b/backend/locales/zh-CN.json
@@ -425,5 +425,9 @@
   "folder_select_error": "选择文件夹时发生错误",
   "folder_select": "选择文件夹",
   "proxy_page_range": "显示 {start}-{end}",
-  "settings_saved": "设置已保存。"
+  "settings_saved": "设置已保存。",
+  "file_name_queued": "文件名待获取",
+  "file_name_fetching": "正在获取文件名…",
+  "file_name_failed": "无法获取文件名",
+  "file_name_unresolved": "文件名未找到"
 }

--- a/backend/locales/zh-TW.json
+++ b/backend/locales/zh-TW.json
@@ -425,5 +425,9 @@
   "folder_select_error": "選擇資料夾時發生錯誤",
   "folder_select": "選擇資料夾",
   "proxy_page_range": "顯示 {start}-{end}",
-  "settings_saved": "設定已儲存。"
+  "settings_saved": "設定已儲存。",
+  "file_name_queued": "檔名待取得",
+  "file_name_fetching": "正在取得檔名…",
+  "file_name_failed": "無法取得檔名",
+  "file_name_unresolved": "找不到檔名"
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1456,14 +1456,30 @@
     return !name || /^1fichier:/i.test(name.trim());
   }
 
-  // What to actually show in the filename cell. A `1fichier:<id>` placeholder
-  // means the real name hasn't been fetched yet (not that the file is missing),
-  // so surface the file id as an identifier instead of a misleading "없음".
-  function displayFileName(name) {
-    if (!name) return $t("file_name_na");
-    const m = name.trim().match(/^1fichier:(.+)$/i);
-    if (m) return m[1];
-    return name;
+  // What to show in the filename cell. When the real name hasn't been fetched
+  // yet (placeholder like `1fichier:<id>`), reflect *why* via the download
+  // status so "queued / fetching / failed / done-but-unresolved" are
+  // distinguishable instead of a single ambiguous "없음".
+  function displayFileName(download) {
+    const name = download?.filename;
+    if (name && !isPlaceholderName(name)) return name;
+    const st = (download?.status || "").toLowerCase();
+    if (st === "pending") return $t("file_name_queued");
+    if (["parsing", "proxying", "downloading", "waiting"].includes(st))
+      return $t("file_name_fetching");
+    if (st === "failed" || st === "stopped") return $t("file_name_failed");
+    if (st === "done") return $t("file_name_unresolved");
+    // Unknown status — fall back to the 1fichier id if present, else N/A.
+    const m = (name || "").trim().match(/^1fichier:(.+)$/i);
+    return m ? m[1] : $t("file_name_na");
+  }
+
+  // Tooltip: the real name, or the 1fichier id when only a placeholder exists.
+  function fileNameTitle(download) {
+    const name = download?.filename;
+    if (name && !isPlaceholderName(name)) return name;
+    const m = (name || "").trim().match(/^1fichier:(.+)$/i);
+    return m ? `1fichier: ${m[1]}` : displayFileName(download);
   }
 
   function getStatusTooltip(download) {
@@ -2287,10 +2303,10 @@
                   </td>
                   <td
                     class="filename"
-                    title={displayFileName(download.filename)}
+                    title={fileNameTitle(download)}
                   >
                     <span class="filename-text"
-                      >{displayFileName(download.filename)}</span
+                      >{displayFileName(download)}</span
                     >
                   </td>
                   <td class="center-align">


### PR DESCRIPTION
## Point (from user)
A row with no real filename couldn't be told apart: is the name **not fetched yet**, **being fetched**, **failed**, or **will be fetched**? It all collapsed to one ambiguous label.

## Fix
When the filename is still a placeholder (e.g. `1fichier:<id>` before parsing), render a **state-aware label derived from the download status**:

| status | label (ko) | meaning |
|---|---|---|
| pending | 파일명 대기 중 | queued — will fetch |
| parsing / proxying / downloading / waiting | 파일명 가져오는 중… | fetching now |
| failed / stopped | 파일명 못 가져옴 | fetch failed |
| done (still placeholder) | 파일명 확인 불가 | completed but couldn't resolve |

The 1fichier file id moves to the cell tooltip.

## i18n
Adds 4 keys (`file_name_queued/fetching/failed/unresolved`) to **all 18 locales** (Korean + English/translated). Locale-parity + i18n tests pass (170).

`npm run build` passes. CSS/JS/locale only; `:latest` rebuilds on merge.