### PR TITLE
fix(ui): usage skeleton stuck until refresh on first-time login

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -426,6 +426,14 @@
     fetchActiveDownloads();
     fetchProxyStatus();
     checkProxyAvailability();
+
+    // System monitoring was gated behind auth in onMount, so a first-time login
+    // (no token yet at mount) never started it — the usage skeleton stayed until
+    // a manual refresh. Kick it off (and its interval) here too.
+    fetchSystemStats();
+    if (!systemStatsInterval) {
+      systemStatsInterval = setInterval(fetchSystemStats, 5000);
+    }
   }
 
   function handleResetProxyStatus() {


### PR DESCRIPTION
## Symptom
On first entry, the **usage (system monitoring) skeleton** never resolves; a manual refresh fixes it.

## Cause
`fetchSystemStats()` and its 5s interval are started only inside the auth-gated block in `onMount` (`if (!$needsLogin || $isAuthenticated)`). On a **first-time login** there's no token at mount, so that block is skipped. `handleLoginSuccess()` then reloads downloads / SSE / proxy / availability — **but not the system stats** — so `systemStats` stays `null` and the monitor skeleton stays up. A refresh re-mounts with the token present, so the block runs and it resolves (which is why only the usage side was affected).

## Fix
Start `fetchSystemStats()` and the interval in `handleLoginSuccess()` as well.

`npm run build` passes. JS only; `:latest` rebuilds on merge.