### PR TITLE
fix(ui): show cooldown countdown on '일시 차단' rows

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2346,6 +2346,10 @@
                       {:else if download.status.toLowerCase() === "failed" && download.failure_kind}
                         <!-- On failure show a single label: the classified reason (detail in tooltip) -->
                         {$t("kind_" + download.failure_kind)}
+                        {#if download.next_retry_at && new Date(download.next_retry_at).getTime() > currentTime}
+                          <!-- Show the cooldown countdown so it's clear when a retry becomes possible -->
+                          <span class="wait-countdown">({formatWaitTime((new Date(download.next_retry_at).getTime() - currentTime) / 1000)})</span>
+                        {/if}
                       {:else}
                         {$t(`download_${download.status.toLowerCase()}`)}
                         {#if ["proxying", "parsing", "downloading"].includes(download.status.toLowerCase())}


### PR DESCRIPTION
## Why
'일시 차단' (temporary block / `kind_blocked`) sets `next_retry_at = now + 120s`, but the time was only in the retry button's hover tooltip — so it looked like there was no way to know when the block clears.

## Fix
Render a live **mm:ss countdown** next to the failure label for any failed row whose `next_retry_at` is in the future (uses the existing 1-second `currentTime` ticker + `formatWaitTime`). It disappears once the cooldown clears.

## Notes
- Blocked items don't auto-retry on a timer; after the cooldown a manual retry / 일괄 재시작 proceeds (batch restart skips items still in cooldown). The countdown makes that wait visible.
- Retries already go through the logged-in 1fichier account (account cookies are fetched in `start_download_async`), when login succeeds.

`npm run build` passes. JS only; `:latest` rebuilds on merge.