### PR TITLE
fix(ui): 'today' period filter returned yesterday's items (UTC vs local)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -504,7 +504,15 @@
   // Dashboard date helper: compute start/end YYYY-MM-DD from dashboardPeriod
   function getDashboardDateRange() {
     const today = new Date();
-    const fmt = (d) => d.toISOString().slice(0, 10);
+    // Use the LOCAL date, not toISOString() (UTC). requested_at is stored in
+    // local time, so a UTC date made "today" resolve to yesterday during the
+    // local morning (e.g. KST 00:00–09:00), surfacing yesterday's items.
+    const fmt = (d) => {
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
+      return `${y}-${m}-${dd}`;
+    };
     const todayStr = fmt(today);
 
     switch (dashboardPeriod) {


### PR DESCRIPTION
## Symptom
The **오늘 (today)** dashboard period filter shows **yesterday's** downloads.

## Cause
`getDashboardDateRange()` formatted the date range with `d.toISOString().slice(0,10)` = **UTC** date. But `requested_at` is stored in **local** time (`datetime.now()`, container `TZ=Asia/Seoul`). During the local morning (KST 00:00–09:00) the UTC date is still *yesterday*, so 'today' queried the wrong day and returned yesterday's items. (The 7d/30d ranges were also shifted by the UTC offset.)

## Fix
Format the range from **local date components** (`getFullYear/getMonth/getDate`), matching `HistoryPeriodControls.toIsoDate`.

`npm run build` passes. JS only; `:latest` rebuilds on merge.