### PR TITLE
fix(ui): wait countdown disappears during parsing (event race)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -658,7 +658,16 @@
             downloads = downloads.map((d, i) =>
               i === currentIndex ? { ...d, ...updatedDownload } : d
             );
-            if (updatedDownload.status !== "waiting" && downloadWaitInfo[downloadId]) {
+            // Only clear the wait countdown when the download genuinely leaves
+            // the wait (started downloading / finished / failed / stopped). A
+            // stray "parsing"/"proxying" status_update mid-wait must NOT wipe an
+            // active countdown — that left rows stuck on "파싱중" with no timer.
+            if (
+              ["downloading", "done", "failed", "stopped"].includes(
+                (updatedDownload.status || "").toLowerCase(),
+              ) &&
+              downloadWaitInfo[downloadId]
+            ) {
               delete downloadWaitInfo[downloadId];
               downloadWaitInfo = { ...downloadWaitInfo };
             }
@@ -2337,12 +2346,12 @@
                           <span class="row-audit-spinner"></span>
                           {$t("action_audit_running")}
                         </span>
-                      {:else if download.status.toLowerCase() === "waiting" && downloadWaitInfo[download.id] && downloadWaitInfo[download.id].remaining_time > 0}
+                      {:else if downloadWaitInfo[download.id] && downloadWaitInfo[download.id].remaining_time > 0 && ["waiting", "parsing", "proxying", "pending"].includes(download.status.toLowerCase())}
+                        <!-- An active 1fichier wait countdown — show it even if the
+                             status field is still 'parsing'/'proxying' (events race). -->
                         <span class="wait-countdown">
                           {$t("download_waiting_time")} ({formatWaitTime(downloadWaitInfo[download.id].remaining_time)})
-                          <span
-                            class="wait-indicator wait-indicator-{download.status.toLowerCase()}"
-                          ></span>
+                          <span class="wait-indicator wait-indicator-waiting"></span>
                         </span>
                       {:else if download.status.toLowerCase() === "downloading" && !download.progress}
                         <span class="wait-countdown">


### PR DESCRIPTION
## Symptom (suspected by user)
During the **parsing** state the 1fichier wait countdown isn't shown — the row sits on '파싱중' with no timer.

## Cause
The backend sends the wait state as two separate SSE events: a `status_update{status:'waiting'}` and the `waiting` countdown ticks. The UI:
- rendered the countdown **only** while `status === 'waiting'`, and
- **deleted** `downloadWaitInfo` on any `status_update` whose status != 'waiting'.

So a stray `parsing`/`proxying` status_update interleaving with the wait events wiped the countdown, leaving '파싱중' with no timer.

## Fix
- Show the countdown whenever `remaining_time > 0` and the status is a pre-download state (`waiting/parsing/proxying/pending`).
- Clear the wait info only on `downloading/done/failed/stopped` (the `wait_countdown_complete` and `download_stopped` handlers still clear it too).

`npm run build` passes. JS only; `:latest` rebuilds on merge.