### PR TITLE
docs: scope description to 1fichier + DataNodes

### DIFF
--- a/README_KR.md
+++ b/README_KR.md
@@ -2,14 +2,14 @@
 
 ![Project Banner](https://raw.githubusercontent.com/jshsakura/oc-proxy-downloader/main/docs/banner.png)
 
-**프록시 기반 1fichier 다운로드 관리 시스템**
+**1fichier · DataNodes 다운로드 관리 시스템 (프록시 기반)**
 
 FastAPI + Svelte로 구성된 웹 애플리케이션으로, 프록시를 통한 안정적인 파일 다운로드를 지원합니다.
 
 ## ✨ 주요 기능
 
 - 🚀 **1fichier 최적화**: 자동 대기시간 감지 및 쿨다운 관리 (최대 24시간 대기)
-- 🧪 **실험적 멀티 호스팅 지원**: MegaUp/DataNodes/GoFile(공개 링크) 자동 해석 지원, Send.now/Rapidgator 및 GoFile 프리미엄 전용 링크 제약은 명확한 실패 사유로 안내
+- 🧩 **DataNodes 지원**: DataNodes 링크 자동 해석 및 다운로드
 - 🔄 **스마트 프록시**: 자동 순환, 실패 감지, 로컬/프록시 혼합 다운로드
 - 📊 **실시간 모니터링**: SSE 기반 실시간 상태 업데이트 및 진행률 표시
 - 🎯 **동시 다운로드 제한**: 시스템 안정성을 위한 세마포어 기반 제한

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,14 @@
 
 ![Project Banner](https://raw.githubusercontent.com/jshsakura/oc-proxy-downloader/main/docs/banner.png)
 
-**Proxy-based 1fichier Download Management System**
+**1fichier & DataNodes download manager (proxy-based)**
 
 A web application built with FastAPI + Svelte that provides stable file downloads through proxy servers.
 
 ## ✨ Key Features
 
 - 🚀 **1fichier Optimized**: Automatic wait time detection and cooldown management (up to 24-hour wait)
+- 🧩 **DataNodes Support**: Automatic DataNodes link resolution and download
 - 🔄 **Smart Proxy**: Auto-rotation, failure detection, mixed local/proxy downloads
 - 📊 **Real-time Monitoring**: SSE-based real-time status updates and progress display
 - 🎯 **Concurrent Download Limits**: Semaphore-based limits for system stability


### PR DESCRIPTION
Per request: advertise only the two hosts that work reliably (1fichier, DataNodes). MegaUp/GoFile/Send.now/Rapidgator parsers stay in the code for internal use but are dropped from the README (unreliable from blocked server IPs).

- Tagline → "1fichier & DataNodes download manager (proxy-based)".
- Replace the experimental multi-hosting bullet with a DataNodes support bullet (EN + KR).