### PR TITLE
fix(1fichier): show real quota recovery time (not a 10-min default)

### DIFF
--- a/backend/core/simple_parser.py
+++ b/backend/core/simple_parser.py
@@ -358,8 +358,13 @@ def parse_1fichier_simple_sync(url, password=None, proxies=None, proxy_addr=None
         if wait_seconds and wait_seconds > MAX_WAIT_SECONDS:
             # Abnormally long wait → daily/rate limit. Don't hang in "parsing".
             print(f"[LOG] 대기시간 과다: {wait_seconds}초 (상한 {MAX_WAIT_SECONDS}초)")
+            # Embed the wait as "you must wait N minutes" so classify_error's
+            # _extract_retry_after captures the *real* wait — the next_retry_at
+            # then reflects when 1fichier actually unlocks, instead of defaulting
+            # to 10 min. ("대기시간이 너무" still routes it to the rate_limited kind.)
             raise Exception(
-                f"1fichier 대기시간이 너무 깁니다 ({wait_seconds // 60}분) — 무료 다운로드 한도일 수 있습니다. 잠시 후 다시 시도하세요"
+                f"1fichier 대기시간이 너무 깁니다 — 무료 다운로드 한도 "
+                f"(you must wait {wait_seconds // 60} minutes)"
             )
         if wait_seconds:
             print(f"[LOG] 대기시간: {wait_seconds}초")

--- a/backend/tests/test_error_messages.py
+++ b/backend/tests/test_error_messages.py
@@ -315,3 +315,28 @@ class TestRetryGate:
         # item is released after a system update.
         req = _FakeReq(error="[파싱 실패] ... (페이지 로드 실패: HTTP 404)")
         assert is_retry_blocked_now(req, has_credentials=True) is None
+
+
+class TestRateLimitRealWait:
+    """The 1fichier '대기시간이 너무 깁니다' failure must carry the *real* wait
+    time so next_retry_at reflects when the quota actually unlocks (not a flat
+    10-min default). Regression for the 'don't know when it clears' issue."""
+
+    def test_long_wait_message_yields_rate_limited_with_real_retry_after(self):
+        msg = "1fichier 대기시간이 너무 깁니다 — 무료 다운로드 한도 (you must wait 240 minutes)"
+        c = classify_error("파싱", msg)
+        assert c.kind == KIND_RATE_LIMITED
+        assert c.retry_after_seconds == 240 * 60
+
+    def test_next_retry_at_matches_stated_wait(self):
+        future = datetime.datetime.now() + datetime.timedelta(minutes=240)
+        req = _FakeReq()
+        verdict = apply_failure_to_request(
+            req, "파싱",
+            "1fichier 대기시간이 너무 깁니다 — 무료 다운로드 한도 (you must wait 240 minutes)",
+        )
+        assert verdict.kind == KIND_RATE_LIMITED
+        # next_retry_at ~ now + 240min (+60s margin), well beyond the old 10-min default
+        assert req.next_retry_at is not None
+        delta = (req.next_retry_at - datetime.datetime.now()).total_seconds()
+        assert 240 * 60 <= delta <= 240 * 60 + 120

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1462,8 +1462,14 @@
   function formatWaitTime(seconds) {
     if (seconds == null || seconds < 0) return "0:00";
     const total = Math.max(0, Math.floor(seconds));
-    const m = Math.floor(total / 60);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
     const s = total % 60;
+    // Long quota waits (1fichier free limit) can be hours — show H:MM:SS so the
+    // countdown reads as a real recovery time instead of e.g. "240:30".
+    if (h > 0) {
+      return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+    }
     return `${m}:${s.toString().padStart(2, "0")}`;
   }
 


### PR DESCRIPTION
## Problem
A 1fichier item stuck on the free-download **quota** showed no usable info on *when* it clears — it just looked like a permanent fail / a vague block.

## Cause
When 1fichier's stated wait exceeded the 30-min cap, we failed with a message containing the wait as `(N분)`. `classify_error._extract_retry_after` couldn't parse that form, so `next_retry_at` fell back to the flat **10-minute** rate_limited default → the cooldown countdown (PR #19) showed a wrong time, and retrying at 10 min just hit the quota again.

## Fix
- **Backend** (`simple_parser`): phrase the over-cap failure as `you must wait N minutes` so the real wait flows into `retry_after` → `next_retry_at` = the actual unlock time. (`대기시간이 너무` still routes it to the `rate_limited` kind.)
- **Frontend** (`formatWaitTime`): render **H:MM:SS** for waits ≥ 1h, so a multi-hour quota reads as a real recovery countdown (e.g. `4:00:30`) instead of `240:30`.

Now a quota row shows **1fichier 한도 (H:MM:SS)** counting down to the real unlock time — you can see when it clears.

## Tests
- Added regression tests: the over-cap message classifies as `rate_limited` with `retry_after = N*60`, and `next_retry_at` matches the stated wait (not 10 min).
- Full suite: **442 passed**, frontend build OK.