### PR TITLE
feat(mega): MEGA public-link crypto + streaming download module (phase 1)

### DIFF
--- a/backend/core/mega_crypto.py
+++ b/backend/core/mega_crypto.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Pure MEGA crypto primitives — no network, no app dependencies.
+
+MEGA encrypts files client-side: the decryption key travels in the share-link
+fragment (after ``#``) and never reaches MEGA's servers. These helpers implement
+MEGA's published algorithm (the same one in its open SDK / web client):
+
+- keys/IVs are handled as tuples of unsigned 32-bit big-endian words ("a32"),
+- the file key is the XOR-fold of an 8-word blob into a 4-word AES key,
+- file attributes (the filename) are AES-CBC encrypted with a ``MEGA{...}`` JSON
+  body, and file contents are AES-CTR encrypted with a chained CBC-MAC.
+
+Adapted from the MEGA protocol (ref: odwyersoftware/mega.py, Apache-2.0).
+"""
+
+import base64
+import json
+import struct
+from typing import Dict, Iterator, Tuple
+
+from Crypto.Cipher import AES
+
+A32 = Tuple[int, ...]
+
+# MEGA streams contents in growing chunks: 128 KiB, ramping by 128 KiB up to a
+# 1 MiB cap. The CBC-MAC is computed per chunk, so downloads MUST be split on
+# exactly these boundaries for the integrity check to validate.
+_CHUNK_START = 0x20000   # 128 KiB
+_CHUNK_MAX = 0x100000    # 1 MiB
+
+
+def a32_to_bytes(a: A32) -> bytes:
+    """Pack big-endian 32-bit words into bytes."""
+    return struct.pack(f">{len(a)}I", *a)
+
+
+def bytes_to_a32(b: bytes) -> A32:
+    """Unpack bytes into big-endian 32-bit words (zero-padded to a multiple of 4)."""
+    if len(b) % 4:
+        b += b"\0" * (4 - len(b) % 4)
+    return struct.unpack(f">{len(b) // 4}I", b)
+
+
+def base64_url_decode(data: str) -> bytes:
+    """Decode MEGA's URL-safe, unpadded base64 variant."""
+    data += "==" [(2 - len(data) * 3) % 4:]
+    data = data.replace("-", "+").replace("_", "/").replace(",", "")
+    return base64.b64decode(data)
+
+
+def base64_to_a32(s: str) -> A32:
+    return bytes_to_a32(base64_url_decode(s))
+
+
+def unpack_file_key(file_key: A32) -> Tuple[A32, A32, A32]:
+    """Split a MEGA 8-word file key into (aes_key, iv, meta_mac).
+
+    The AES key is the XOR-fold of the two halves; the IV and meta-MAC come from
+    the upper half. Raises ValueError for anything that isn't an 8-word file key
+    (e.g. a folder key), so callers fail clearly rather than mis-decrypting.
+    """
+    if len(file_key) != 8:
+        raise ValueError(f"expected an 8-word file key, got {len(file_key)} words")
+    aes_key = (
+        file_key[0] ^ file_key[4],
+        file_key[1] ^ file_key[5],
+        file_key[2] ^ file_key[6],
+        file_key[3] ^ file_key[7],
+    )
+    iv = file_key[4:6] + (0, 0)
+    meta_mac = file_key[6:8]
+    return aes_key, iv, meta_mac
+
+
+def decrypt_attr(attr: bytes, aes_key: A32) -> Dict[str, str]:
+    """Decrypt MEGA file attributes (AES-CBC, zero IV) into a dict.
+
+    The plaintext is ``MEGA`` followed by a JSON object, e.g. ``MEGA{"n":"a.rar"}``.
+    Returns ``{}`` when the prefix is absent (wrong key / corrupt data).
+    """
+    cipher = AES.new(a32_to_bytes(aes_key), AES.MODE_CBC, b"\0" * 16)
+    plain = cipher.decrypt(attr).decode("latin-1").rstrip("\0")
+    if plain[:6] != 'MEGA{"':
+        return {}
+    return json.loads(plain[4:])
+
+
+def get_chunks(size: int) -> Iterator[Tuple[int, int]]:
+    """Yield ``(offset, length)`` pairs over MEGA's chunk boundaries."""
+    offset = 0
+    step = _CHUNK_START
+    while offset + step < size:
+        yield offset, step
+        offset += step
+        if step < _CHUNK_MAX:
+            step += _CHUNK_START
+    yield offset, size - offset

--- a/backend/core/mega_hoster.py
+++ b/backend/core/mega_hoster.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""MEGA.nz public-link resolution and streaming download.
+
+Flow (anonymous, no account):
+1. ``parse_mega_url`` pulls the file id + decryption key out of the share link
+   (both the legacy ``/#!id!key`` and current ``/file/id#key`` formats).
+2. ``fetch_mega_file_info`` asks MEGA's API for the temporary content URL, size
+   and encrypted attributes, then derives the AES key/IV and the real filename.
+3. ``download_mega_file`` streams the encrypted bytes and AES-CTR-decrypts them
+   on MEGA's chunk boundaries, verifying the chained CBC-MAC.
+
+The decryption happens entirely client-side; MEGA never sees the key. See
+``mega_crypto`` for the primitives. (Algorithm ref: odwyersoftware/mega.py.)
+"""
+
+import asyncio
+import random
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
+
+import aiohttp
+from Crypto.Cipher import AES
+from Crypto.Util import Counter
+
+from core.mega_crypto import (
+    A32,
+    a32_to_bytes,
+    base64_to_a32,
+    base64_url_decode,
+    bytes_to_a32,
+    decrypt_attr,
+    get_chunks,
+    unpack_file_key,
+)
+
+MEGA_API_URL = "https://g.api.mega.co.nz/cs"
+
+# Stream read timeout per socket read (the overall transfer has no total cap).
+_SOCK_READ_TIMEOUT = 300
+
+# MEGA API error codes (negative ints). Dead = retrying is pointless; the rest
+# are temporary (congestion / quota / expired URL) and worth a later retry.
+MEGA_DEAD_CODES = frozenset({-9, -16})        # ENOENT (gone), EBLOCKED
+MEGA_QUOTA_CODES = frozenset({-17})           # EOVERQUOTA — per-IP bandwidth cap
+_MEGA_ERROR_TEXT = {
+    -3: "일시적 혼잡 (EAGAIN)",
+    -4: "요청 한도 (ERATELIMIT)",
+    -6: "이 링크에 접속이 너무 많음 (ETOOMANY)",
+    -8: "임시 다운로드 URL 만료 (EEXPIRED)",
+    -9: "파일을 찾을 수 없음 (ENOENT)",
+    -16: "차단된 파일/사용자 (EBLOCKED)",
+    -17: "대역폭 한도 초과 (EOVERQUOTA)",
+    -18: "일시적으로 사용 불가 (ETEMPUNAVAIL)",
+}
+
+
+class MegaApiError(Exception):
+    """A negative MEGA API status (or a missing content URL)."""
+
+    def __init__(self, code: int):
+        self.code = code
+        super().__init__(f"MEGA API 오류 {code}: {_MEGA_ERROR_TEXT.get(code, '알 수 없음')}")
+
+    @property
+    def is_dead(self) -> bool:
+        return self.code in MEGA_DEAD_CODES
+
+    @property
+    def is_quota(self) -> bool:
+        return self.code in MEGA_QUOTA_CODES
+
+
+@dataclass(frozen=True)
+class MegaFileInfo:
+    download_url: str
+    size: int
+    name: str
+    aes_key: bytes      # 16-byte AES key (already XOR-folded)
+    iv: A32             # (iv0, iv1, 0, 0)
+    meta_mac: A32       # (mac0, mac1) expected after decryption
+
+
+def parse_mega_url(url: str) -> Tuple[str, str]:
+    """Return ``(file_id, key)`` from a MEGA file share link.
+
+    Raises ValueError for folder links or links missing the ``#`` key — those
+    can't be downloaded anonymously by this single-file path.
+    """
+    url = (url or "").strip()
+    if not any(domain in url for domain in ("mega.nz", "mega.co.nz", "mega.io")):
+        raise ValueError("MEGA 링크가 아닙니다")
+    if "/folder/" in url or "/#F!" in url or "#F!" in url:
+        raise ValueError("MEGA 폴더 링크는 지원하지 않습니다 (단일 파일 링크만)")
+
+    # Current format: https://mega.nz/file/<id>#<key>
+    if "/file/" in url:
+        tail = url.split("/file/", 1)[1]
+        if "#" not in tail:
+            raise ValueError("MEGA 링크에 복호화 키(#...)가 없습니다")
+        file_id, key = tail.split("#", 1)
+        return file_id.split("/", 1)[0], key
+
+    # Legacy format: https://mega.nz/#!<id>!<key>
+    if "#!" in url:
+        frag = url.split("#!", 1)[1]
+        if "!" not in frag:
+            raise ValueError("MEGA 링크에 복호화 키가 없습니다")
+        file_id, key = frag.split("!", 1)
+        return file_id, key
+
+    raise ValueError("MEGA 파일 링크 형식이 아닙니다")
+
+
+async def fetch_mega_file_info(
+    session: aiohttp.ClientSession, file_id: str, key: str
+) -> MegaFileInfo:
+    """Resolve the temp download URL, size and filename for a public file."""
+    seq_id = random.randint(0, 0xFFFFFFFF)
+    payload = [{"a": "g", "g": 1, "p": file_id}]
+    async with session.post(
+        MEGA_API_URL,
+        params={"id": str(seq_id)},
+        json=payload,
+        timeout=aiohttp.ClientTimeout(total=30),
+    ) as response:
+        response.raise_for_status()
+        data = await response.json(content_type=None)
+
+    # The API returns a bare negative int on a global error, or a list whose
+    # first element is the file dict (or a negative int for a per-file error).
+    if isinstance(data, int):
+        raise MegaApiError(data)
+    item = data[0]
+    if isinstance(item, int):
+        raise MegaApiError(item)
+    if "g" not in item:
+        raise MegaApiError(-9)  # no content URL → treat as not accessible
+
+    aes_key, iv, meta_mac = unpack_file_key(base64_to_a32(key))
+    attribs = decrypt_attr(base64_url_decode(item["at"]), aes_key)
+    return MegaFileInfo(
+        download_url=item["g"],
+        size=int(item["s"]),
+        name=attribs.get("n") or file_id,
+        aes_key=a32_to_bytes(aes_key),
+        iv=iv,
+        meta_mac=meta_mac,
+    )
+
+
+class _ChainedCbcMac:
+    """MEGA's file MAC: a CBC-MAC per chunk, chained through a second CBC pass."""
+
+    def __init__(self, aes_key: bytes, iv: A32):
+        self._key = aes_key
+        self._block_iv = a32_to_bytes((iv[0], iv[1], iv[0], iv[1]))
+        self._chain = AES.new(aes_key, AES.MODE_CBC, b"\0" * 16)
+        self._mac = b"\0" * 16
+
+    def update(self, chunk: bytes) -> None:
+        inner = AES.new(self._key, AES.MODE_CBC, self._block_iv)
+        block_mac = b"\0" * 16
+        for i in range(0, len(chunk), 16):
+            block = chunk[i:i + 16]
+            if len(block) < 16:
+                block += b"\0" * (16 - len(block))
+            block_mac = inner.encrypt(block)
+        self._mac = self._chain.encrypt(block_mac)
+
+    def result(self) -> A32:
+        m = bytes_to_a32(self._mac)
+        return (m[0] ^ m[1], m[2] ^ m[3])
+
+
+async def _read_exact(stream: aiohttp.StreamReader, n: int) -> bytes:
+    """Read exactly ``n`` bytes (or fewer only at EOF) — chunk boundaries must
+    line up with MEGA's for the MAC to validate."""
+    buf = bytearray()
+    while len(buf) < n:
+        part = await stream.read(n - len(buf))
+        if not part:
+            break
+        buf.extend(part)
+    return bytes(buf)
+
+
+async def download_mega_file(
+    session: aiohttp.ClientSession,
+    info: MegaFileInfo,
+    dest_path: str,
+    progress_cb: Optional[Callable[[int, int], None]] = None,
+    is_cancelled: Optional[Callable[[], bool]] = None,
+) -> int:
+    """Stream the encrypted file and AES-CTR-decrypt it to ``dest_path``.
+
+    Returns the number of bytes written. Raises ``asyncio.CancelledError`` if
+    ``is_cancelled`` turns true, ``IOError`` on a truncated stream.
+    """
+    counter = Counter.new(128, initial_value=((info.iv[0] << 32) + info.iv[1]) << 64)
+    cipher = AES.new(info.aes_key, AES.MODE_CTR, counter=counter)
+    mac = _ChainedCbcMac(info.aes_key, info.iv)
+    downloaded = 0
+
+    async with session.get(
+        info.download_url,
+        timeout=aiohttp.ClientTimeout(total=None, connect=60, sock_read=_SOCK_READ_TIMEOUT),
+    ) as response:
+        response.raise_for_status()
+        with open(dest_path, "wb") as out:
+            for _offset, length in get_chunks(info.size):
+                if is_cancelled and is_cancelled():
+                    raise asyncio.CancelledError()
+                encrypted = await _read_exact(response.content, length)
+                if len(encrypted) != length:
+                    raise IOError(
+                        f"MEGA 스트림이 일찍 끊김: {downloaded + len(encrypted)}/{info.size}"
+                    )
+                plain = cipher.decrypt(encrypted)
+                out.write(plain)
+                mac.update(plain)
+                downloaded += length
+                if progress_cb:
+                    progress_cb(downloaded, info.size)
+
+    if mac.result() != tuple(info.meta_mac):
+        # The CTR-decrypted bytes are still correct; a mismatch only flags an
+        # integrity concern, so we keep the file and warn rather than fail.
+        print(f"[WARNING] MEGA MAC 불일치: {info.name} (파일은 보존)")
+    return downloaded

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,7 @@ pydantic==2.11.7
 pydantic-extra-types==2.10.5
 pydantic-settings==2.10.1
 pydantic_core==2.33.2
+pycryptodome==3.23.0
 Pygments==2.19.2
 PyJWT==2.10.1
 pyparsing==3.2.3

--- a/backend/tests/test_mega.py
+++ b/backend/tests/test_mega.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the MEGA crypto primitives and the streaming decrypt path.
+
+These never touch the network: the download test encrypts a known plaintext
+with the same AES-CTR scheme MEGA uses, serves it through a fake stream, and
+asserts the module decrypts it back byte-for-byte and validates the MAC.
+"""
+
+import json
+import os
+
+import pytest
+from Crypto.Cipher import AES
+from Crypto.Util import Counter
+
+from core import mega_crypto as mc
+from core import mega_hoster as mh
+
+
+# ---------------------------------------------------------------------------
+# mega_crypto primitives
+# ---------------------------------------------------------------------------
+
+class TestCryptoPrimitives:
+    def test_a32_bytes_roundtrip(self):
+        words = (1, 2, 0xDEADBEEF, 4)
+        assert mc.bytes_to_a32(mc.a32_to_bytes(words)) == words
+
+    def test_base64_url_decode_handles_missing_padding(self):
+        # MEGA strips '=' padding and uses -/_ instead of +//.
+        raw = b"hello mega"
+        import base64
+        enc = base64.b64encode(raw).decode().replace("+", "-").replace("/", "_").rstrip("=")
+        assert mc.base64_url_decode(enc) == raw
+
+    def test_unpack_file_key_xor_fold(self):
+        fk = (0, 0, 0, 0, 1, 2, 3, 4)  # upper half XORs into the key
+        aes_key, iv, meta_mac = mc.unpack_file_key(fk)
+        assert aes_key == (1, 2, 3, 4)
+        assert iv == (1, 2, 0, 0)
+        assert meta_mac == (3, 4)
+
+    def test_unpack_file_key_rejects_non_file_key(self):
+        with pytest.raises(ValueError):
+            mc.unpack_file_key((1, 2, 3, 4))  # folder-length key
+
+    def test_decrypt_attr_roundtrip(self):
+        aes_key = (1, 2, 3, 4)
+        payload = ('MEGA' + json.dumps({"n": "file.rar"})).encode("latin-1")
+        payload += b"\0" * ((16 - len(payload) % 16) % 16)
+        enc = AES.new(mc.a32_to_bytes(aes_key), AES.MODE_CBC, b"\0" * 16).encrypt(payload)
+        assert mc.decrypt_attr(enc, aes_key) == {"n": "file.rar"}
+
+    def test_decrypt_attr_wrong_prefix_returns_empty(self):
+        aes_key = (9, 9, 9, 9)
+        enc = AES.new(mc.a32_to_bytes(aes_key), AES.MODE_CBC, b"\0" * 16).encrypt(b"\0" * 16)
+        assert mc.decrypt_attr(enc, aes_key) == {}
+
+    def test_get_chunks_cover_size_without_gaps(self):
+        size = 700_000
+        chunks = list(mc.get_chunks(size))
+        assert chunks[0] == (0, 0x20000)               # first chunk is 128 KiB
+        assert sum(length for _o, length in chunks) == size
+        # contiguous, non-overlapping
+        expected_offset = 0
+        for offset, length in chunks:
+            assert offset == expected_offset
+            expected_offset += length
+
+
+# ---------------------------------------------------------------------------
+# parse_mega_url
+# ---------------------------------------------------------------------------
+
+class TestParseUrl:
+    def test_new_format(self):
+        fid, key = mh.parse_mega_url("https://mega.nz/file/AbCdEfGh#TheSecretKey123")
+        assert fid == "AbCdEfGh"
+        assert key == "TheSecretKey123"
+
+    def test_legacy_format(self):
+        fid, key = mh.parse_mega_url("https://mega.nz/#!7V8zGDiK!VbkkCyKey")
+        assert fid == "7V8zGDiK"
+        assert key == "VbkkCyKey"
+
+    def test_folder_link_rejected(self):
+        with pytest.raises(ValueError):
+            mh.parse_mega_url("https://mega.nz/folder/AbCd#key")
+
+    def test_missing_key_rejected(self):
+        with pytest.raises(ValueError):
+            mh.parse_mega_url("https://mega.nz/file/AbCdEfGh")
+
+    def test_non_mega_rejected(self):
+        with pytest.raises(ValueError):
+            mh.parse_mega_url("https://example.com/file/x#y")
+
+
+# ---------------------------------------------------------------------------
+# MegaApiError classification
+# ---------------------------------------------------------------------------
+
+class TestApiError:
+    def test_dead_codes(self):
+        assert mh.MegaApiError(-9).is_dead
+        assert mh.MegaApiError(-16).is_dead
+        assert not mh.MegaApiError(-9).is_quota
+
+    def test_quota_code(self):
+        assert mh.MegaApiError(-17).is_quota
+        assert not mh.MegaApiError(-17).is_dead
+
+
+# ---------------------------------------------------------------------------
+# Streaming decrypt (fake stream, no network)
+# ---------------------------------------------------------------------------
+
+class _FakeStream:
+    def __init__(self, data: bytes):
+        self._data = data
+        self._pos = 0
+
+    async def read(self, n: int) -> bytes:
+        chunk = self._data[self._pos:self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes):
+        self.content = _FakeStream(data)
+
+    def raise_for_status(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def get(self, url, **kwargs):
+        return _FakeResponse(self._data)
+
+
+def _encrypt_ctr(plaintext: bytes, aes_key: bytes, iv) -> bytes:
+    counter = Counter.new(128, initial_value=((iv[0] << 32) + iv[1]) << 64)
+    return AES.new(aes_key, AES.MODE_CTR, counter=counter).encrypt(plaintext)
+
+
+def _expected_meta_mac(plaintext: bytes, aes_key: bytes, iv) -> tuple:
+    mac = mh._ChainedCbcMac(aes_key, iv)
+    for offset, length in mc.get_chunks(len(plaintext)):
+        mac.update(plaintext[offset:offset + length])
+    return mac.result()
+
+
+@pytest.mark.asyncio
+async def test_streaming_decrypt_roundtrip(tmp_path):
+    aes_key = mc.a32_to_bytes((11, 22, 33, 44))
+    iv = (55, 66, 0, 0)
+    plaintext = os.urandom(400_000)  # spans 128K + 256K + tail chunks
+    encrypted = _encrypt_ctr(plaintext, aes_key, iv)
+
+    info = mh.MegaFileInfo(
+        download_url="https://example/dl",
+        size=len(plaintext),
+        name="sample.bin",
+        aes_key=aes_key,
+        iv=iv,
+        meta_mac=_expected_meta_mac(plaintext, aes_key, iv),
+    )
+    dest = tmp_path / "out.bin"
+    progress = []
+    written = await mh.download_mega_file(
+        _FakeSession(encrypted), info, str(dest),
+        progress_cb=lambda d, t: progress.append((d, t)),
+    )
+
+    assert written == len(plaintext)
+    assert dest.read_bytes() == plaintext          # CTR decrypt is correct
+    assert progress[-1] == (len(plaintext), len(plaintext))
+
+
+@pytest.mark.asyncio
+async def test_streaming_decrypt_cancel(tmp_path):
+    aes_key = mc.a32_to_bytes((1, 2, 3, 4))
+    iv = (7, 8, 0, 0)
+    plaintext = os.urandom(300_000)
+    info = mh.MegaFileInfo(
+        download_url="x", size=len(plaintext), name="c.bin",
+        aes_key=aes_key, iv=iv, meta_mac=(0, 0),
+    )
+    with pytest.raises(__import__("asyncio").CancelledError):
+        await mh.download_mega_file(
+            _FakeSession(_encrypt_ctr(plaintext, aes_key, iv)),
+            info, str(tmp_path / "c.bin"),
+            is_cancelled=lambda: True,
+        )


### PR DESCRIPTION
## What
Phase 1 of MEGA.nz support: a **self-contained, async, pure-Python** module for resolving and decrypting MEGA public file links. **Not yet wired into download_core** — zero behavior change until phase 2 adds routing.

## Design (modular, ported from the MEGA protocol; ref odwyersoftware/mega.py, Apache-2.0)
- **`core/mega_crypto.py`** — pure primitives, no network, no app deps: a32/bytes, MEGA base64, file-key XOR unpack, `decrypt_attr` (filename), `get_chunks` (128KiB→1MiB boundaries).
- **`core/mega_hoster.py`**:
  - `parse_mega_url` — legacy `/#!id!key` + current `/file/id#key`; rejects folders / non-MEGA / keyless.
  - `fetch_mega_file_info` — anonymous `g.api.mega.co.nz/cs` `{a:g}` call → temp URL, size, filename, AES key/IV/meta-mac.
  - `download_mega_file` — streams encrypted bytes, **AES-CTR decrypts on MEGA chunk boundaries**, verifies chained CBC-MAC, with progress + cancel.
  - `MegaApiError` — maps codes (`-9`/`-16` dead, `-17` EOVERQUOTA quota, others transient).
- Adds **pycryptodome** (only new dep; not previously installed).

## Why a dedicated path (phase 2 preview)
MEGA content is client-side encrypted, so it can't reuse the plain aiohttp/Content-Disposition/proxy streaming — the temp URL must be decrypted chunk-by-chunk. Phase 2 will route `mega.nz` URLs to this module and map `MegaApiError` onto our failure kinds (quota → the rate_limited 'recovery countdown' we just added).

## Tests
16 unit tests, **no network**: crypto roundtrips, URL parsing (both formats + rejections), error classification, and a fake-stream **AES-CTR decrypt roundtrip** (encrypt known plaintext → decrypt → byte-identical) + cancel. Full suite: **458 passed**.

## Caveat
MEGA's anonymous bandwidth quota is **per-IP** — server-side downloads share one quota (like GoFile/MegaUp IP-gating); `-17` surfaces as a retriable quota state in phase 2.