### PR TITLE
fix(mega): apply decrypted filename (legacy #! links showed 'mega.nz')

### DIFF
--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -1827,8 +1827,11 @@ class DownloadCore:
             async with aiohttp.ClientSession() as session:
                 info = await fetch_mega_file_info(session, file_id, key)
 
-                if _should_replace_file_name(req.file_name, info.name):
-                    req.file_name = info.name
+                # MEGA's decrypted attributes are the authoritative name — apply
+                # unconditionally. (The URL alone only yields a host/id
+                # placeholder, e.g. "mega.nz", which can carry a '.' and would
+                # otherwise be mistaken for an already-resolved name.)
+                req.file_name = info.name
                 req.total_size = info.size
                 req.file_size = _format_bytes(info.size)
                 if req.original_url != req.url:

--- a/backend/core/simple_parser.py
+++ b/backend/core/simple_parser.py
@@ -165,6 +165,16 @@ def derive_display_name(url: str) -> str:
         if m:
             return f"1fichier:{m.group(1)}"
 
+    # MEGA: the id sits in the fragment (#!id!key) or path (/file/id), and the
+    # real name only comes from decrypting attributes during the download. Show
+    # the file id meanwhile so it's an identifier (and dot-free → replaceable).
+    if "mega.nz" in host or "mega.co.nz" in host or "mega.io" in host:
+        frag = parsed.fragment or ""
+        if frag.startswith("!"):
+            return f"mega:{frag[1:].split('!', 1)[0]}"
+        if "/file/" in (parsed.path or ""):
+            return f"mega:{parsed.path.split('/file/', 1)[1].split('/', 1)[0]}"
+
     # Generic URL: last path segment, falling back to the host
     path = (parsed.path or "").rstrip("/")
     if path:

--- a/backend/tests/test_mega.py
+++ b/backend/tests/test_mega.py
@@ -227,3 +227,16 @@ class TestErrorClassification:
         assert mh.is_mega_url("https://mega.nz/#!abc!key")
         assert not mh.is_mega_url("https://mega.nz/folder/abc#key")
         assert not mh.is_mega_url("https://1fichier.com/?x")
+
+
+class TestDeriveDisplayName:
+    """The pre-parse placeholder for MEGA must be a dot-free id (so it's later
+    replaceable), not the host 'mega.nz' which carries a '.' and looked resolved."""
+
+    def test_legacy_link_yields_mega_id(self):
+        from core.simple_parser import derive_display_name
+        assert derive_display_name("https://mega.nz/#!7V8zGDiK!key") == "mega:7V8zGDiK"
+
+    def test_new_link_yields_mega_id(self):
+        from core.simple_parser import derive_display_name
+        assert derive_display_name("https://mega.nz/file/AbCdEfGh#key") == "mega:AbCdEfGh"

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1482,9 +1482,10 @@
     return speed + " " + sizes[i];
   }
 
-  // A name like "1fichier:<id>" is a temporary URL-derived placeholder, not a real filename.
+  // A name like "1fichier:<id>" / "mega:<id>" is a temporary URL-derived
+  // placeholder (the real name arrives after parsing/decryption), not a filename.
   function isPlaceholderName(name) {
-    return !name || /^1fichier:/i.test(name.trim());
+    return !name || /^(1fichier|mega):/i.test(name.trim());
   }
 
   // What to show in the filename cell. When the real name hasn't been fetched
@@ -1500,17 +1501,17 @@
       return $t("file_name_fetching");
     if (st === "failed" || st === "stopped") return $t("file_name_failed");
     if (st === "done") return $t("file_name_unresolved");
-    // Unknown status — fall back to the 1fichier id if present, else N/A.
-    const m = (name || "").trim().match(/^1fichier:(.+)$/i);
+    // Unknown status — fall back to the id portion if present, else N/A.
+    const m = (name || "").trim().match(/^(?:1fichier|mega):(.+)$/i);
     return m ? m[1] : $t("file_name_na");
   }
 
-  // Tooltip: the real name, or the 1fichier id when only a placeholder exists.
+  // Tooltip: the real name, or the host:id when only a placeholder exists.
   function fileNameTitle(download) {
     const name = download?.filename;
     if (name && !isPlaceholderName(name)) return name;
-    const m = (name || "").trim().match(/^1fichier:(.+)$/i);
-    return m ? `1fichier: ${m[1]}` : displayFileName(download);
+    const m = (name || "").trim().match(/^(1fichier|mega):(.+)$/i);
+    return m ? `${m[1]}: ${m[2]}` : displayFileName(download);
   }
 
   function getStatusTooltip(download) {


### PR DESCRIPTION
## Symptom
MEGA downloads showed no real filename (legacy `#!id!key` links displayed `mega.nz`).

## Root cause (decryption was fine — verified on a live link)
`fetch_mega_file_info` decrypts the real name correctly. The bug was in *applying* it: for a legacy `#!id!key` link, `derive_display_name` fell back to the **host `mega.nz`**, which contains a `.`, so `_name_needs_resolution` saw it as 'already resolved' → `_should_replace_file_name` refused to overwrite → the row kept `mega.nz`.

## Fix
- **`_download_mega_async`**: set `req.file_name = info.name` **unconditionally** — MEGA's decrypted attributes are authoritative.
- **`derive_display_name`**: return a dot-free `mega:<id>` placeholder for both link formats (from the fragment or `/file/` path) instead of the host, so it's recognized as replaceable.
- **frontend**: `isPlaceholderName`/`displayFileName`/`fileNameTitle` treat `mega:` like `1fichier:` → pre-parse row shows the fetch-state label, id in tooltip.

## Tests
Live-link check (offline-safe in CI) + `derive_display_name` MEGA tests. Full suite **464 passed**; frontend build OK.