### PR TITLE
fix(gofile): send the website token (wt) the listing API now requires

### DIFF
--- a/backend/core/hoster_parsers.py
+++ b/backend/core/hoster_parsers.py
@@ -32,9 +32,16 @@ FLARESOLVERR_REQUEST_TIMEOUT_S = int(os.environ.get("FLARESOLVERR_REQUEST_TIMEOU
 
 GOFILE_API_BASE = "https://api.gofile.io"
 _GOFILE_ID_RE = re.compile(r"/(?:d/)?([A-Za-z0-9]+)/?$")
+# The listing API requires the site's "website token" (wt). The web client reads
+# it from /dist/js/config.js; we fetch it live and fall back to the last-known
+# value if the format changes. Without wt the API returns error-notPremium even
+# from a residential IP — which previously looked like a datacenter-IP block.
+GOFILE_CONFIG_JS_URL = "https://gofile.io/dist/js/config.js"
+GOFILE_FALLBACK_WT = "4fd6sg89d7s6"
+_GOFILE_WT_RE = re.compile(r"""wt\s*[:=]\s*["']([A-Za-z0-9_\-]{6,})["']""")
 # Query params the GoFile web client sends for a folder listing (captured live).
-# Note: the listing API is gated by datacenter IP — it returns error-notPremium
-# from cloud/VPS IPs but works from residential IPs (e.g. a home NAS).
+# Note: even with wt, the listing API is also gated by datacenter IP — it returns
+# error-notPremium from cloud/VPS IPs but works from residential IPs (home NAS).
 _GOFILE_CONTENTS_PARAMS = {
     "contentFilter": "",
     "page": "1",
@@ -665,12 +672,19 @@ def _gofile_guest_token(session: requests.Session) -> str:
     return (payload.get("data") or {}).get("token") or ""
 
 
+def _gofile_website_token(session: requests.Session) -> str:
+    """Read the site's website token (wt) from config.js, with a static fallback."""
+    response = session.get(GOFILE_CONFIG_JS_URL, timeout=30)
+    match = _GOFILE_WT_RE.search(response.text or "")
+    return match.group(1) if match else GOFILE_FALLBACK_WT
+
+
 def _gofile_fetch_contents(
-    session: requests.Session, content_id: str, token: str
+    session: requests.Session, content_id: str, token: str, wt: str
 ) -> Dict[str, object]:
     response = session.get(
         f"{GOFILE_API_BASE}/contents/{content_id}",
-        params=_GOFILE_CONTENTS_PARAMS,
+        params={**_GOFILE_CONTENTS_PARAMS, "wt": wt},
         headers={"Authorization": f"Bearer {token}"},
         timeout=30,
     )
@@ -726,7 +740,8 @@ def parse_gofile_sync(url: str) -> Dict[str, object]:
     if not token:
         raise HosterParseError("Gofile 게스트 토큰 발급 실패")
 
-    payload = _gofile_fetch_contents(session, content_id, token)
+    wt = _gofile_website_token(session)
+    payload = _gofile_fetch_contents(session, content_id, token, wt)
     status = str(payload.get("status") or "")
     if status == "error-notPremium":
         raise HosterParseError(

--- a/backend/tests/test_hoster_parsers.py
+++ b/backend/tests/test_hoster_parsers.py
@@ -228,6 +228,7 @@ def test_blocked_hosts_are_identified():
 def _patch_gofile_tokens(monkeypatch):
     monkeypatch.setattr(hp, "_gofile_session", lambda: object())
     monkeypatch.setattr(hp, "_gofile_guest_token", lambda session: "guest-tok")
+    monkeypatch.setattr(hp, "_gofile_website_token", lambda session: "test-wt")
 
 
 def test_gofile_content_id_extraction():
@@ -292,7 +293,7 @@ def test_gofile_datacenter_ip_block_is_reported(monkeypatch):
         hp.parse_special_hoster_sync("https://gofile.io/d/6uARDV")
 
 
-def test_gofile_contents_call_omits_wt_and_uses_web_params(monkeypatch):
+def test_gofile_contents_call_includes_wt_and_web_params(monkeypatch):
     captured = {}
 
     class _Resp:
@@ -311,12 +312,32 @@ def test_gofile_contents_call_omits_wt_and_uses_web_params(monkeypatch):
 
     monkeypatch.setattr(hp, "_gofile_session", lambda: _Sess())
     monkeypatch.setattr(hp, "_gofile_guest_token", lambda session: "guest-tok")
+    monkeypatch.setattr(hp, "_gofile_website_token", lambda session: "wt-123")
 
     hp.parse_special_hoster_sync("https://gofile.io/d/abc")
 
-    assert "wt" not in (captured["params"] or {})
+    # wt is now required by GoFile's listing API and must be sent.
+    assert captured["params"]["wt"] == "wt-123"
     assert captured["params"]["pageSize"] == "1000"
     assert captured["headers"]["Authorization"] == "Bearer guest-tok"
+
+
+def test_gofile_website_token_extracted_with_fallback(monkeypatch):
+    class _Resp:
+        def __init__(self, text):
+            self.text = text
+
+    class _Sess:
+        def __init__(self, text):
+            self._text = text
+
+        def get(self, url, timeout=None):
+            return _Resp(self._text)
+
+    # Extracted from config.js
+    assert hp._gofile_website_token(_Sess('const x = {wt: "abc123def"};')) == "abc123def"
+    # Falls back to the last-known value when the pattern is absent
+    assert hp._gofile_website_token(_Sess("no token here")) == hp.GOFILE_FALLBACK_WT
 
 
 def test_gofile_missing_content_is_reported_as_dead(monkeypatch):


### PR DESCRIPTION
## Symptom
GoFile failed with '데이터센터 IP 차단' **even from a home/NAS IP** ('집인데 뭔데').

## Root cause (diagnosed against the live site)
GoFile's `/contents` listing API requires a **website token (`wt`)** query param. We never sent it, so the API returned `error-notPremium` — which our code reported as a datacenter-IP block, even on a residential IP where it was actually the missing `wt`.

The `wt` also **moved**: the old `/dist/js/global.js` is now a 156-byte stub; the token now lives in `/dist/js/config.js` (value `4fd6sg89d7s6`).

## Fix
- `_gofile_website_token`: fetch `wt` live from `config.js` (regex), with a last-known fallback if the format changes again.
- Include `wt` in the `/contents` request.

## Honest caveat
Confirmed via a VPS that GoFile **also** gates the listing by datacenter IP — even with the correct wt + browser headers + fresh guest token, a datacenter IP still gets `error-notPremium`. So:
- **Residential/home IP that previously failed for lack of wt → should now work.**
- **Datacenter IP → still blocked** (the message stays accurate). I couldn't verify the home-IP success from here (my test IP is a datacenter), so please confirm on the NAS.

## Tests
Updated gofile tests (wt now required) + wt-extraction/fallback test. Full suite **465 passed**.