### PR TITLE
feat: configurable FlareSolverr URL in Settings + host-support docs

### DIFF
--- a/README_KR.md
+++ b/README_KR.md
@@ -2,14 +2,15 @@
 
 ![Project Banner](https://raw.githubusercontent.com/jshsakura/oc-proxy-downloader/main/docs/banner.png)
 
-**1fichier · DataNodes 다운로드 관리 시스템 (프록시 기반)**
+**1fichier · MEGA · DataNodes 다운로드 관리자 — 프록시 기반, Docker 컨테이너 / Windows 앱으로 실행**
 
-FastAPI + Svelte로 구성된 웹 애플리케이션으로, 프록시를 통한 안정적인 파일 다운로드를 지원합니다.
+FastAPI + Svelte 웹 앱으로, 1fichier·MEGA·DataNodes(및 Docker에서 MegaUp/GoFile) 안정적 다운로드 + 프록시 지원.
 
 ## ✨ 주요 기능
 
-- 🚀 **1fichier 최적화**: 자동 대기시간 감지 및 쿨다운 관리 (최대 24시간 대기)
-- 🧩 **DataNodes 지원**: DataNodes 링크 자동 해석 및 다운로드
+- 🚀 **1fichier 최적화**: 자동 대기시간 감지 및 쿨다운 관리 (최대 24시간 대기), 한도 복구 시각 카운트다운 표시
+- 🔐 **MEGA 지원**: 공개 링크 다운로드 + 클라이언트 측 AES 복호화 (파일명/크기/진행률)
+- 🧩 **DataNodes / MegaUp / GoFile**: 링크 자동 해석 및 다운로드 (MegaUp/GoFile은 FlareSolverr 필요 — 아래 참고)
 - 🔄 **스마트 프록시**: 자동 순환, 실패 감지, 로컬/프록시 혼합 다운로드
 - 📊 **실시간 모니터링**: SSE 기반 실시간 상태 업데이트 및 진행률 표시
 - 🎯 **동시 다운로드 제한**: 시스템 안정성을 위한 세마포어 기반 제한
@@ -18,6 +19,16 @@ FastAPI + Svelte로 구성된 웹 애플리케이션으로, 프록시를 통한 
 - 🌐 **다국어**: 18개 언어 지원 (한국어·영어·일본어·중국어 간체/번체·스페인어·프랑스어·독일어·러시아어·포르투갈어(BR)·이탈리아어·베트남어·인도네시아어·태국어·터키어·폴란드어·아랍어(RTL)·네덜란드어). 언어 파일(`backend/locales/*.json`)만 추가하면 자동 인식
 - 📱 **반응형 UI**: 모바일/데스크톱 최적화
 - 🛡️ **선택적 인증**: JWT 기반 보안 (선택사항)
+
+## 🌩️ 호스트 지원 & FlareSolverr
+
+| 호스트 | FlareSolverr 필요 | Windows 앱(번들 없음) |
+|--------|-------------------|------------------------|
+| 1fichier, MEGA | 불필요 | ✅ 됨 |
+| DataNodes | Cloudflare 챌린지 때만 | 🟡 챌린지 안 뜨면 됨 |
+| MegaUp, GoFile | 필요 (Cloudflare) | ❌ 외부 FlareSolverr 필요 |
+
+FlareSolverr는 **`docker-compose.yml`에 사이드카로 번들**되어 자동 연결됩니다. 주소는 **설정 → FlareSolverr URL**(또는 `FLARESOLVERR_URL` 환경변수)에서 바꿀 수 있습니다 — Windows 앱에서 별도로 띄운 FlareSolverr를 가리킬 때 유용합니다. (GoFile 목록 조회는 데이터센터 IP도 차단하므로 가정용/NAS IP에서 가장 잘 됩니다.)
 
 ---
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -69,7 +69,10 @@ def get_default_download_path():
 DEFAULT_CONFIG = {
     "download_path": get_default_download_path(),
     "theme": "light",
-    "language": "ko"
+    "language": "ko",
+    # FlareSolverr endpoint for Cloudflare-protected hosts (MegaUp/GoFile/etc.).
+    # Empty → fall back to the FLARESOLVERR_URL env var, then http://localhost:8191.
+    "flaresolverr_url": ""
 }
 
 def get_config():

--- a/backend/core/hoster_parsers.py
+++ b/backend/core/hoster_parsers.py
@@ -21,12 +21,24 @@ import cloudscraper
 import requests
 from bs4 import BeautifulSoup
 
+from core.config import get_config
+
 
 DEFAULT_HOSTER_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
 )
 DEFAULT_FLARESOLVERR_URL = os.environ.get("FLARESOLVERR_URL", "http://localhost:8191")
+
+
+def resolve_flaresolverr_url() -> str:
+    """FlareSolverr endpoint, in priority order: settings → env var → default.
+
+    Resolved at call time so the in-app Settings value takes effect without a
+    restart (and so the Windows app can point at a separately-run FlareSolverr).
+    """
+    configured = (get_config().get("flaresolverr_url") or "").strip()
+    return configured or DEFAULT_FLARESOLVERR_URL
 FLARESOLVERR_MAX_TIMEOUT_MS = int(os.environ.get("FLARESOLVERR_MAX_TIMEOUT_MS", "60000"))
 FLARESOLVERR_REQUEST_TIMEOUT_S = int(os.environ.get("FLARESOLVERR_REQUEST_TIMEOUT_S", "80"))
 
@@ -189,7 +201,7 @@ def _flaresolverr_request_get(
         }
     try:
         response = requests.post(
-            f"{DEFAULT_FLARESOLVERR_URL.rstrip('/')}/v1",
+            f"{resolve_flaresolverr_url().rstrip('/')}/v1",
             json=payload,
             timeout=FLARESOLVERR_REQUEST_TIMEOUT_S,
         )

--- a/backend/locales/ar.json
+++ b/backend/locales/ar.json
@@ -429,5 +429,8 @@
   "file_name_queued": "الاسم قيد الانتظار",
   "file_name_fetching": "جارٍ جلب الاسم…",
   "file_name_failed": "الاسم غير متوفر",
-  "file_name_unresolved": "لم يُعثر على الاسم"
+  "file_name_unresolved": "لم يُعثر على الاسم",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/de.json
+++ b/backend/locales/de.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Name ausstehend",
   "file_name_fetching": "Name wird abgerufen…",
   "file_name_failed": "Name nicht verfügbar",
-  "file_name_unresolved": "Name nicht gefunden"
+  "file_name_unresolved": "Name nicht gefunden",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/en.json
+++ b/backend/locales/en.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Name pending",
   "file_name_fetching": "Fetching name…",
   "file_name_failed": "Name unavailable",
-  "file_name_unresolved": "Name not found"
+  "file_name_unresolved": "Name not found",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/es.json
+++ b/backend/locales/es.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Nombre pendiente",
   "file_name_fetching": "Obteniendo nombre…",
   "file_name_failed": "Nombre no disponible",
-  "file_name_unresolved": "Nombre no encontrado"
+  "file_name_unresolved": "Nombre no encontrado",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/fr.json
+++ b/backend/locales/fr.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Nom en attente",
   "file_name_fetching": "Récupération du nom…",
   "file_name_failed": "Nom indisponible",
-  "file_name_unresolved": "Nom introuvable"
+  "file_name_unresolved": "Nom introuvable",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/id.json
+++ b/backend/locales/id.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Nama menunggu",
   "file_name_fetching": "Mengambil nama…",
   "file_name_failed": "Nama tidak tersedia",
-  "file_name_unresolved": "Nama tidak ditemukan"
+  "file_name_unresolved": "Nama tidak ditemukan",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/it.json
+++ b/backend/locales/it.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Nome in attesa",
   "file_name_fetching": "Recupero nome…",
   "file_name_failed": "Nome non disponibile",
-  "file_name_unresolved": "Nome non trovato"
+  "file_name_unresolved": "Nome non trovato",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/ja.json
+++ b/backend/locales/ja.json
@@ -429,5 +429,8 @@
   "file_name_queued": "ファイル名待機中",
   "file_name_fetching": "ファイル名取得中…",
   "file_name_failed": "ファイル名取得失敗",
-  "file_name_unresolved": "ファイル名不明"
+  "file_name_unresolved": "ファイル名不明",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/ko.json
+++ b/backend/locales/ko.json
@@ -429,5 +429,8 @@
   "file_name_queued": "파일명 대기 중",
   "file_name_fetching": "파일명 가져오는 중…",
   "file_name_failed": "파일명 못 가져옴",
-  "file_name_unresolved": "파일명 확인 불가"
+  "file_name_unresolved": "파일명 확인 불가",
+  "flaresolverr_url_label": "FlareSolverr 주소",
+  "flaresolverr_url_hint": "Cloudflare 보호 호스트(MegaUp/GoFile 등)용. 비우면 기본값(localhost:8191)을 사용합니다.",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/nl.json
+++ b/backend/locales/nl.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Naam in afwachting",
   "file_name_fetching": "Naam ophalen…",
   "file_name_failed": "Naam niet beschikbaar",
-  "file_name_unresolved": "Naam niet gevonden"
+  "file_name_unresolved": "Naam niet gevonden",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/pl.json
+++ b/backend/locales/pl.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Nazwa oczekuje",
   "file_name_fetching": "Pobieranie nazwy…",
   "file_name_failed": "Nazwa niedostępna",
-  "file_name_unresolved": "Nazwa nieznaleziona"
+  "file_name_unresolved": "Nazwa nieznaleziona",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/pt-BR.json
+++ b/backend/locales/pt-BR.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Nome pendente",
   "file_name_fetching": "Obtendo nome…",
   "file_name_failed": "Nome indisponível",
-  "file_name_unresolved": "Nome não encontrado"
+  "file_name_unresolved": "Nome não encontrado",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/ru.json
+++ b/backend/locales/ru.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Имя ожидается",
   "file_name_fetching": "Получение имени…",
   "file_name_failed": "Имя недоступно",
-  "file_name_unresolved": "Имя не найдено"
+  "file_name_unresolved": "Имя не найдено",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/th.json
+++ b/backend/locales/th.json
@@ -429,5 +429,8 @@
   "file_name_queued": "รอชื่อไฟล์",
   "file_name_fetching": "กำลังดึงชื่อ…",
   "file_name_failed": "ไม่มีชื่อไฟล์",
-  "file_name_unresolved": "ไม่พบชื่อไฟล์"
+  "file_name_unresolved": "ไม่พบชื่อไฟล์",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/tr.json
+++ b/backend/locales/tr.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Ad bekleniyor",
   "file_name_fetching": "Ad alınıyor…",
   "file_name_failed": "Ad kullanılamıyor",
-  "file_name_unresolved": "Ad bulunamadı"
+  "file_name_unresolved": "Ad bulunamadı",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/vi.json
+++ b/backend/locales/vi.json
@@ -429,5 +429,8 @@
   "file_name_queued": "Đang chờ tên",
   "file_name_fetching": "Đang lấy tên…",
   "file_name_failed": "Không có tên",
-  "file_name_unresolved": "Không tìm thấy tên"
+  "file_name_unresolved": "Không tìm thấy tên",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/zh-CN.json
+++ b/backend/locales/zh-CN.json
@@ -429,5 +429,8 @@
   "file_name_queued": "文件名待获取",
   "file_name_fetching": "正在获取文件名…",
   "file_name_failed": "无法获取文件名",
-  "file_name_unresolved": "文件名未找到"
+  "file_name_unresolved": "文件名未找到",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/zh-TW.json
+++ b/backend/locales/zh-TW.json
@@ -429,5 +429,8 @@
   "file_name_queued": "檔名待取得",
   "file_name_fetching": "正在取得檔名…",
   "file_name_failed": "無法取得檔名",
-  "file_name_unresolved": "找不到檔名"
+  "file_name_unresolved": "找不到檔名",
+  "flaresolverr_url_label": "FlareSolverr URL",
+  "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/services/ouo_unwrap_service.py
+++ b/backend/services/ouo_unwrap_service.py
@@ -22,6 +22,7 @@ from typing import Optional
 import requests
 
 from core.ouo_resolver import OuoResolver, OuoResolverConfig
+from core.hoster_parsers import resolve_flaresolverr_url
 
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,8 @@ def _flaresolverr_reachable(url: str) -> bool:
 
 
 def _build_resolver() -> OuoResolver:
-    has_flaresolverr = _flaresolverr_reachable(_DEFAULT_FLARESOLVERR_URL)
+    flaresolverr_url = resolve_flaresolverr_url()
+    has_flaresolverr = _flaresolverr_reachable(flaresolverr_url)
     if has_flaresolverr:
         backend_order = (
             "curl_impersonate",
@@ -74,7 +76,7 @@ def _build_resolver() -> OuoResolver:
             "undetected_chromedriver",
             "ouo_bypass_legacy",
         )
-        logger.info(f"OuoResolver: FlareSolverr reachable at {_DEFAULT_FLARESOLVERR_URL}, using full backend chain")
+        logger.info(f"OuoResolver: FlareSolverr reachable at {flaresolverr_url}, using full backend chain")
     else:
         # Standalone (e.g. Windows binary without docker stack) — curl_impersonate
         # is the only backend that doesn't need FlareSolverr.
@@ -82,7 +84,7 @@ def _build_resolver() -> OuoResolver:
         logger.info("OuoResolver: FlareSolverr unreachable, standalone mode (curl_impersonate only)")
 
     config = OuoResolverConfig(
-        flaresolverr_url=_DEFAULT_FLARESOLVERR_URL,
+        flaresolverr_url=flaresolverr_url,
         allowed_download_hosts=_ALLOWED_HOSTS,
         accept_intermediate_hosts=False,
         preserve_unresolved_ouo_links=False,

--- a/frontend/src/lib/SettingsModal.svelte
+++ b/frontend/src/lib/SettingsModal.svelte
@@ -311,6 +311,7 @@
       telegram_notify_start: currentSettings.telegram_notify_start === true,
       fichier_email: currentSettings.fichier_email || "",
       fichier_password: currentSettings.fichier_password || "",
+      flaresolverr_url: currentSettings.flaresolverr_url || "",
     };
     selectedTheme = settings.theme || $theme;
     originalTheme = $theme;
@@ -1157,6 +1158,20 @@
                 </div>
               </div>
             {/if}
+          </fieldset>
+
+          <fieldset class="form-group">
+            <legend>FlareSolverr</legend>
+            <label for="flaresolverr-url">{$t("flaresolverr_url_label")}</label>
+            <input
+              id="flaresolverr-url"
+              type="text"
+              class="input"
+              autocomplete="off"
+              placeholder={$t("flaresolverr_url_placeholder")}
+              bind:value={settings.flaresolverr_url}
+            />
+            <small class="input-hint">{$t("flaresolverr_url_hint")}</small>
           </fieldset>
 
           <fieldset class="form-group telegram-notifications">

--- a/readme.md
+++ b/readme.md
@@ -2,14 +2,15 @@
 
 ![Project Banner](https://raw.githubusercontent.com/jshsakura/oc-proxy-downloader/main/docs/banner.png)
 
-**1fichier & DataNodes download manager (proxy-based)**
+**1fichier · MEGA · DataNodes download manager — proxy-based, runs as a Docker container or a Windows app**
 
-A web application built with FastAPI + Svelte that provides stable file downloads through proxy servers.
+A FastAPI + Svelte web app for stable downloads from 1fichier, MEGA, DataNodes (and MegaUp/GoFile in Docker), with proxy support.
 
 ## ✨ Key Features
 
-- 🚀 **1fichier Optimized**: Automatic wait time detection and cooldown management (up to 24-hour wait)
-- 🧩 **DataNodes Support**: Automatic DataNodes link resolution and download
+- 🚀 **1fichier Optimized**: Automatic wait time detection and cooldown management (up to 24-hour wait), with a visible quota-recovery countdown
+- 🔐 **MEGA Support**: Public-link download with client-side AES decryption (filename, size, progress)
+- 🧩 **DataNodes / MegaUp / GoFile**: Automatic link resolution and download (MegaUp/GoFile need FlareSolverr — see below)
 - 🔄 **Smart Proxy**: Auto-rotation, failure detection, mixed local/proxy downloads
 - 📊 **Real-time Monitoring**: SSE-based real-time status updates and progress display
 - 🎯 **Concurrent Download Limits**: Semaphore-based limits for system stability
@@ -18,6 +19,16 @@ A web application built with FastAPI + Svelte that provides stable file download
 - 🌐 **Multilingual**: Full Korean/English support
 - 📱 **Responsive UI**: Mobile/Desktop optimized
 - 🛡️ **Optional Authentication**: JWT-based security (optional)
+
+## 🌩️ Host support & FlareSolverr
+
+| Host | Needs FlareSolverr | Windows app (no bundled FlareSolverr) |
+|------|--------------------|----------------------------------------|
+| 1fichier, MEGA | No | ✅ Works |
+| DataNodes | Only when Cloudflare-challenged | 🟡 Works unless challenged |
+| MegaUp, GoFile | Yes (Cloudflare) | ❌ Needs an external FlareSolverr |
+
+FlareSolverr is **bundled in `docker-compose.yml`** (sidecar) and wired automatically. You can override its address in **Settings → FlareSolverr URL** (or the `FLARESOLVERR_URL` env var) — useful for the Windows app, where you can point it at a separately-run FlareSolverr. (GoFile's listing API is also datacenter-IP gated, so it works best from a home/NAS IP.)
 
 ---
 


### PR DESCRIPTION
Addresses the batch of requests: make FlareSolverr addable from Settings, document MegaUp/MEGA proudly, and improve the intro tagline.

## FlareSolverr URL in Settings
- New `flaresolverr_url` config key. `resolve_flaresolverr_url()` resolves at call time: **Settings → `FLARESOLVERR_URL` env → `http://localhost:8191`** — so the value takes effect without a restart, and the **Windows app** can point at a separately-run FlareSolverr (previously env-only, no UI).
- Used by both the FlareSolverr request (`hoster_parsers`) and the ouo unwrap resolver.
- **SettingsModal**: a FlareSolverr URL field (+ `flaresolverr_url_label/hint/placeholder` in all 18 locales).

## README (EN + KR)
- New tagline: **1fichier · MEGA · DataNodes download manager — proxy-based, Docker container or Windows app**.
- Features now list **MEGA** (AES decrypt) and **MegaUp/GoFile**.
- New **Host support × FlareSolverr** table: which hosts need FlareSolverr and which work in the Windows app (1fichier/MEGA yes; MegaUp/GoFile need it).

## Tests
Full suite **465 passed**, locale parity OK, frontend build OK.