### PR TITLE
docs: advertise only the 4 reliable hosts (1fichier/MEGA/DataNodes/MegaUp)

### DIFF
--- a/README_KR.md
+++ b/README_KR.md
@@ -2,15 +2,15 @@
 
 ![Project Banner](https://raw.githubusercontent.com/jshsakura/oc-proxy-downloader/main/docs/banner.png)
 
-**1fichier · MEGA · DataNodes 다운로드 관리자 — 프록시 기반, Docker 컨테이너 / Windows 앱으로 실행**
+**1fichier · MEGA · DataNodes · MegaUp 다운로드 관리자 — 프록시 기반, Docker 컨테이너 / Windows 앱으로 실행**
 
-FastAPI + Svelte 웹 앱으로, 1fichier·MEGA·DataNodes(및 Docker에서 MegaUp/GoFile) 안정적 다운로드 + 프록시 지원.
+FastAPI + Svelte 웹 앱으로, 1fichier·MEGA·DataNodes·MegaUp(Docker) 안정적 다운로드 + 프록시 지원.
 
 ## ✨ 주요 기능
 
 - 🚀 **1fichier 최적화**: 자동 대기시간 감지 및 쿨다운 관리 (최대 24시간 대기), 한도 복구 시각 카운트다운 표시
 - 🔐 **MEGA 지원**: 공개 링크 다운로드 + 클라이언트 측 AES 복호화 (파일명/크기/진행률)
-- 🧩 **DataNodes / MegaUp / GoFile**: 링크 자동 해석 및 다운로드 (MegaUp/GoFile은 FlareSolverr 필요 — 아래 참고)
+- 🧩 **DataNodes / MegaUp**: 링크 자동 해석 및 다운로드 (MegaUp은 FlareSolverr 필요 — 아래 참고)
 - 🔄 **스마트 프록시**: 자동 순환, 실패 감지, 로컬/프록시 혼합 다운로드
 - 📊 **실시간 모니터링**: SSE 기반 실시간 상태 업데이트 및 진행률 표시
 - 🎯 **동시 다운로드 제한**: 시스템 안정성을 위한 세마포어 기반 제한
@@ -26,9 +26,9 @@ FastAPI + Svelte 웹 앱으로, 1fichier·MEGA·DataNodes(및 Docker에서 MegaU
 |--------|-------------------|------------------------|
 | 1fichier, MEGA | 불필요 | ✅ 됨 |
 | DataNodes | Cloudflare 챌린지 때만 | 🟡 챌린지 안 뜨면 됨 |
-| MegaUp, GoFile | 필요 (Cloudflare) | ❌ 외부 FlareSolverr 필요 |
+| MegaUp | 필요 (Cloudflare) | ❌ 외부 FlareSolverr 필요 |
 
-FlareSolverr는 **`docker-compose.yml`에 사이드카로 번들**되어 자동 연결됩니다. 주소는 **설정 → FlareSolverr URL**(또는 `FLARESOLVERR_URL` 환경변수)에서 바꿀 수 있습니다 — Windows 앱에서 별도로 띄운 FlareSolverr를 가리킬 때 유용합니다. (GoFile 목록 조회는 데이터센터 IP도 차단하므로 가정용/NAS IP에서 가장 잘 됩니다.)
+FlareSolverr는 **`docker-compose.yml`에 사이드카로 번들**되어 자동 연결됩니다. 주소는 **설정 → FlareSolverr URL**(또는 `FLARESOLVERR_URL` 환경변수)에서 바꿀 수 있습니다 — Windows 앱에서 별도로 띄운 FlareSolverr를 가리킬 때 유용합니다.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -2,15 +2,15 @@
 
 ![Project Banner](https://raw.githubusercontent.com/jshsakura/oc-proxy-downloader/main/docs/banner.png)
 
-**1fichier · MEGA · DataNodes download manager — proxy-based, runs as a Docker container or a Windows app**
+**1fichier · MEGA · DataNodes · MegaUp download manager — proxy-based, runs as a Docker container or a Windows app**
 
-A FastAPI + Svelte web app for stable downloads from 1fichier, MEGA, DataNodes (and MegaUp/GoFile in Docker), with proxy support.
+A FastAPI + Svelte web app for stable downloads from 1fichier, MEGA, DataNodes, and MegaUp (Docker), with proxy support.
 
 ## ✨ Key Features
 
 - 🚀 **1fichier Optimized**: Automatic wait time detection and cooldown management (up to 24-hour wait), with a visible quota-recovery countdown
 - 🔐 **MEGA Support**: Public-link download with client-side AES decryption (filename, size, progress)
-- 🧩 **DataNodes / MegaUp / GoFile**: Automatic link resolution and download (MegaUp/GoFile need FlareSolverr — see below)
+- 🧩 **DataNodes / MegaUp**: Automatic link resolution and download (MegaUp needs FlareSolverr — see below)
 - 🔄 **Smart Proxy**: Auto-rotation, failure detection, mixed local/proxy downloads
 - 📊 **Real-time Monitoring**: SSE-based real-time status updates and progress display
 - 🎯 **Concurrent Download Limits**: Semaphore-based limits for system stability
@@ -26,9 +26,9 @@ A FastAPI + Svelte web app for stable downloads from 1fichier, MEGA, DataNodes (
 |------|--------------------|----------------------------------------|
 | 1fichier, MEGA | No | ✅ Works |
 | DataNodes | Only when Cloudflare-challenged | 🟡 Works unless challenged |
-| MegaUp, GoFile | Yes (Cloudflare) | ❌ Needs an external FlareSolverr |
+| MegaUp | Yes (Cloudflare) | ❌ Needs an external FlareSolverr |
 
-FlareSolverr is **bundled in `docker-compose.yml`** (sidecar) and wired automatically. You can override its address in **Settings → FlareSolverr URL** (or the `FLARESOLVERR_URL` env var) — useful for the Windows app, where you can point it at a separately-run FlareSolverr. (GoFile's listing API is also datacenter-IP gated, so it works best from a home/NAS IP.)
+FlareSolverr is **bundled in `docker-compose.yml`** (sidecar) and wired automatically. You can override its address in **Settings → FlareSolverr URL** (or the `FLARESOLVERR_URL` env var) — useful for the Windows app, where you can point it at a separately-run FlareSolverr.
 
 ---
 


### PR DESCRIPTION
Per request, the README should list only hosts that reliably work. Removed **GoFile** from the supported list, features, and the FlareSolverr table — its listing API is datacenter-IP gated and isn't dependable server-side. (The GoFile parser stays in the code for residential/proxy/premium use; just not advertised.)

- Tagline → `1fichier · MEGA · DataNodes · MegaUp`.
- Features → `DataNodes / MegaUp` (GoFile removed).
- Host×FlareSolverr table → 4 rows (GoFile removed).

EN + KR. Docs only.