### PR TITLE
fix(proxy): 실패 시 무한 프록시 재시도 버그 수정

### DIFF
--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -1477,51 +1477,51 @@ class DownloadCore:
                                 if response.status not in [200, 206]:
                                     raise Exception(f"HTTP {response.status}: {response.reason}")
 
-                    # Get Content-Length (don't overwrite a total_size obtained during preparsing)
-                    content_length = response.headers.get('Content-Length')
-                    if content_length and (not req.total_size or req.total_size == 0):
-                        req.total_size = int(content_length) + initial_size
-                        db.commit()
-                        print(f"[LOG] Content-Length로 total_size 설정: {req.total_size}")
+                                # Get Content-Length (don't overwrite a total_size obtained during preparsing)
+                                content_length = response.headers.get('Content-Length')
+                                if content_length and (not req.total_size or req.total_size == 0):
+                                    req.total_size = int(content_length) + initial_size
+                                    db.commit()
+                                    print(f"[LOG] Content-Length로 total_size 설정: {req.total_size}")
 
-                    # Telegram download-start notification (after the HTTP connection succeeds)
-                    try:
-                        file_name = req.file_name or "Unknown File"
-                        file_size = req.file_size
-                        download_mode = "proxy" if proxy_url else "local"
-                        send_telegram_start_notification(file_name, download_mode, "ko", file_size)
-                        print(f"[LOG] 텔레그램 다운로드 시작 알림 전송: {file_name}")
-                    except Exception as telegram_error:
-                        print(f"[WARNING] 텔레그램 다운로드 시작 알림 실패: {telegram_error}")
+                                # Telegram download-start notification (after the HTTP connection succeeds)
+                                try:
+                                    file_name = req.file_name or "Unknown File"
+                                    file_size = req.file_size
+                                    download_mode = "proxy" if proxy_url else "local"
+                                    send_telegram_start_notification(file_name, download_mode, "ko", file_size)
+                                    print(f"[LOG] 텔레그램 다운로드 시작 알림 전송: {file_name}")
+                                except Exception as telegram_error:
+                                    print(f"[WARNING] 텔레그램 다운로드 시작 알림 실패: {telegram_error}")
 
-                    # Actual file download
-                    print(f"[DEBUG] 파일 다운로드 시작 - 초기크기: {initial_size}, 총크기: {req.total_size}")
-                    downloaded_size = await download_file_content(
-                        response, req.save_path, initial_size, req.total_size, req, db
-                    )
-                    print(f"[DEBUG] 파일 다운로드 완료 - 최종크기: {downloaded_size}")
+                                # Actual file download
+                                print(f"[DEBUG] 파일 다운로드 시작 - 초기크기: {initial_size}, 총크기: {req.total_size}")
+                                downloaded_size = await download_file_content(
+                                    response, req.save_path, initial_size, req.total_size, req, db
+                                )
+                                print(f"[DEBUG] 파일 다운로드 완료 - 최종크기: {downloaded_size}")
 
-                    # Rename the .part file to the final file name
-                    final_path = get_final_file_path(req.save_path)
-                    if req.save_path != final_path:
-                        try:
-                            shutil.move(req.save_path, final_path)
-                            print(f"[DEBUG] 파일 리네임: {req.save_path} -> {final_path}")
-                            req.save_path = final_path
-                            db.commit()  # Commit the file path change immediately
-                        except Exception as rename_error:
-                            print(f"[WARNING] 파일 리네임 실패: {rename_error}")
+                                # Rename the .part file to the final file name
+                                final_path = get_final_file_path(req.save_path)
+                                if req.save_path != final_path:
+                                    try:
+                                        shutil.move(req.save_path, final_path)
+                                        print(f"[DEBUG] 파일 리네임: {req.save_path} -> {final_path}")
+                                        req.save_path = final_path
+                                        db.commit()  # Commit the file path change immediately
+                                    except Exception as rename_error:
+                                        print(f"[WARNING] 파일 리네임 실패: {rename_error}")
 
-                    # Completion handling
-                    print(f"[LOG] 다운로드 완료 처리 시작: {req.id}")
-                    req.status = StatusEnum.done
-                    req.downloaded_size = downloaded_size
-                    req.finished_at = datetime.datetime.now()
-                    print(f"[LOG] 상태를 done으로 변경 완료")
+                                # Completion handling
+                                print(f"[LOG] 다운로드 완료 처리 시작: {req.id}")
+                                req.status = StatusEnum.done
+                                req.downloaded_size = downloaded_size
+                                req.finished_at = datetime.datetime.now()
+                                print(f"[LOG] 상태를 done으로 변경 완료")
 
-                    db.commit()
-                    download_success = True
-                    break  # Exit the retry loop on success
+                                db.commit()
+                                download_success = True
+                                break  # Exit the retry loop on success
 
                 except Exception as download_error:
                     print(f"[ERROR] 다운로드 실패 ({retry_count + 1}): {download_error}")


### PR DESCRIPTION
## 문제

`_perform_file_download_async`에서 응답 본문을 읽는 로직이 들여쓰기 오류로 `async with session.get(...) as response:` 및 `async with ClientSession(...)` 블록 **바깥**에 위치했습니다. 그 결과 HTTP 연결/세션이 닫힌 뒤에 `response.content`를 읽으려 해 **매 시도마다 본문 읽기에서 예외**가 발생했습니다.

### 증상
프록시 모드에서 연결은 성공(200/206)하지만 직후 본문 읽기 실패 → `mark_proxy_failed` → 다음 프록시로 재시도 → 동일하게 실패 → 모든 프록시 소진까지 무한 재시도 후 "최대 재시도 횟수 초과".

정상 동작하는 `_download_file_directly`는 응답 처리를 `session.get` 블록 **안**(`_consume_response_and_finish`)에서 수행하는 것과 대비됩니다.

### 영향 경로
- 1fichier 프록시 다운로드 중 파일 정보 보유 시(skip-preparse, `download_core.py:658`)
- 일반/로컬 다운로드(`_perform_local_download_async`, `download_core.py:1695`)

## 수정

응답 본문 처리 블록(Content-Length 확인 → 다운로드 → 리네임 → 완료 처리 → `break`)을 `session.get` 컨텍스트 **안으로 이동**(+12칸 들여쓰기). 열린 연결 위에서 스트리밍이 이뤄지도록 했습니다. `break`는 여전히 `while` 재시도 루프를 정상적으로 빠져나갑니다.

## 테스트
- [x] `python -m ast` 구문 검증 통과
- [x] 전체 백엔드 테스트 464 passed, 1 skipped, 1 xpassed
- [ ] 실제 프록시 환경에서 1fichier 프록시 다운로드 end-to-end 확인 (권장)