### PR TITLE
fix(errors): 1fichier 404 오분류 + GoFile 'IP 차단' 라벨 정정

### DIFF
--- a/backend/core/error_messages.py
+++ b/backend/core/error_messages.py
@@ -210,6 +210,22 @@ _RULES: Tuple[Tuple[str, str, str, str, bool], ...] = (
     ("다운로드 링크를 찾을 수 없음", "1fichier 응답에서 다운로드 링크를 추출하지 못했습니다",
      "잠시 후 다시 시도하거나 프록시 모드를 켜세요.",
      KIND_BLOCKED, False),
+    # A page-load failure that carries an explicit HTTP status must defer to the
+    # status code: 404/410 are link-expiry/session-loss (transient), NOT a dead
+    # URL. These specific rules precede the generic "페이지 로드 실패" catch below
+    # so a 404 isn't mislabeled as "check the URL / blocked".
+    ("페이지 로드 실패: http 404",
+     "1fichier 페이지가 404 를 반환했습니다 (링크 만료 / 일시 세션 손실 / 파일 삭제 가능성)",
+     "다시 시도해주세요. 반복되면 '전체 링크 검수' 로 진짜 죽었는지 확인하세요.",
+     KIND_TRANSIENT, False),
+    ("페이지 로드 실패: http 410",
+     "1fichier 페이지가 410 (Gone) 을 반환했습니다 (링크 만료 / 일시 세션 손실 가능성)",
+     "다시 시도해주세요. 반복되면 '전체 링크 검수' 로 확인하세요.",
+     KIND_TRANSIENT, False),
+    ("페이지 로드 실패: http 503",
+     "1fichier 서버가 일시적으로 점검 중입니다 (페이지 로드 503)",
+     "잠시 후 다시 시도하세요.",
+     KIND_TRANSIENT, False),
     ("페이지 로드 실패", "1fichier 페이지를 가져오지 못했습니다",
      "URL 이 올바른지, 파일이 살아있는지 확인하세요.",
      KIND_BLOCKED, False),

--- a/backend/locales/en.json
+++ b/backend/locales/en.json
@@ -33,7 +33,7 @@
   "kind_auth_required": "Login required",
   "kind_rate_limited": "1fichier limit",
   "kind_cloudflare": "Cloudflare block",
-  "kind_proxy_blocked": "Proxy blocked",
+  "kind_proxy_blocked": "IP blocked (change network)",
   "kind_blocked": "Temporarily blocked",
   "kind_transient": "Transient error",
   "kind_unknown": "Unclassified",

--- a/backend/locales/ko.json
+++ b/backend/locales/ko.json
@@ -33,7 +33,7 @@
   "kind_auth_required": "로그인 필요",
   "kind_rate_limited": "1fichier 한도",
   "kind_cloudflare": "Cloudflare 차단",
-  "kind_proxy_blocked": "프록시 차단",
+  "kind_proxy_blocked": "IP 차단 (망 변경 필요)",
   "kind_blocked": "일시 차단",
   "kind_transient": "일시 오류",
   "kind_unknown": "분류 불명",


### PR DESCRIPTION
## 문제 (사용자 제보)

1. **1fichier 404** — `[파싱 실패] 1fichier 페이지를 가져오지 못했습니다 (페이지 로드 실패: HTTP 404)` / 조치: "URL이 올바른지 확인" 으로 표시되고 **"일시 차단" + 2분 재시도**가 걸림. 실제로는 404(링크 만료/세션 손실)이므로 코드 설계상 `transient`여야 함.
   - 원인: `classify_error`가 규칙을 위에서부터 매칭하는데 일반 규칙 `"페이지 로드 실패"`(KIND_BLOCKED)가 `"http 404"`(KIND_TRANSIENT)보다 앞서 가로챔.

2. **GoFile** — 프록시를 쓰지 않았는데도 실패 시 `kind_proxy_blocked` = **"프록시 차단"** 라벨이 떠서 프록시 탓처럼 보임. GoFile listing 차단은 서버(데이터센터) egress IP 문제.

## 수정

- `error_messages.py`: `"페이지 로드 실패: http 404/410/503"` 구체 규칙을 일반 `"페이지 로드 실패"` 규칙 **앞에** 추가. 404/410 → `transient`(올바른 메시지/재시도), 503 → `transient`. 상태코드 없는 `"페이지 로드 실패"`는 그대로 `blocked`.
- `locales/ko.json`, `en.json`: `kind_proxy_blocked` 라벨을 `"IP 차단 (망 변경 필요)"` / `"IP blocked (change network)"` 로 변경 — 직결/프록시 무관하게 정확.

## 테스트
- [x] 전체 백엔드 464 passed, 1 skipped, 1 xpassed
- [x] `classify_error('파싱','페이지 로드 실패: HTTP 404')` → `transient` 확인, 상태코드 없는 경우 `blocked` 유지
- [x] locale parity 통과 (값만 변경, 키 동일)

NOTE: 나머지 16개 로케일의 `kind_proxy_blocked`는 아직 "Proxy blocked" 계열 — 필요 시 후속 정리.