### PR TITLE
feat(proxy): special hoster 파싱을 프록시로 라우팅 (use_proxy 시)

### DIFF
--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -1725,23 +1725,86 @@ class DownloadCore:
 
         try:
             loop = asyncio.get_event_loop()
-            try:
-                parse_result = await asyncio.wait_for(
-                    loop.run_in_executor(
-                        None,
-                        lambda: parse_special_hoster_sync(req.url, req.password),
-                    ),
-                    timeout=SPECIAL_HOSTER_PARSE_TIMEOUT_SEC,
-                )
-            except asyncio.TimeoutError:
-                # The executor thread may linger until its own bounded calls
-                # finish, but the task fails now so the semaphore slot is freed
-                # and the row leaves the "parsing" state instead of hanging.
-                minutes = SPECIAL_HOSTER_PARSE_TIMEOUT_SEC // 60
-                raise Exception(
-                    f"호스팅 페이지 파싱 시간 초과 ({minutes}분). "
-                    "FlareSolverr 미응답 또는 호스트 차단 가능."
-                )
+            if not req.use_proxy:
+                try:
+                    parse_result = await asyncio.wait_for(
+                        loop.run_in_executor(
+                            None,
+                            lambda: parse_special_hoster_sync(req.url, req.password),
+                        ),
+                        timeout=SPECIAL_HOSTER_PARSE_TIMEOUT_SEC,
+                    )
+                except asyncio.TimeoutError:
+                    # The executor thread may linger until its own bounded calls
+                    # finish, but the task fails now so the semaphore slot is freed
+                    # and the row leaves the "parsing" state instead of hanging.
+                    minutes = SPECIAL_HOSTER_PARSE_TIMEOUT_SEC // 60
+                    raise Exception(
+                        f"호스팅 페이지 파싱 시간 초과 ({minutes}분). "
+                        "FlareSolverr 미응답 또는 호스트 차단 가능."
+                    )
+            else:
+                # Proxy mode: route the parse request through user proxies and
+                # retry across proxies on failure (download step stays direct).
+                total_proxy_list = await proxy_manager.get_user_proxy_list(db)
+                total_proxies = len(total_proxy_list) if total_proxy_list else 0
+                MAX_RETRIES = min(MAX_DOWNLOAD_RETRIES_PROXY_CAP, total_proxies)
+
+                retry_count = 0
+                parse_result = None
+                while parse_result is None and retry_count < MAX_RETRIES:
+                    # Check the download-stopped state
+                    db.refresh(req)
+                    if req.status == StatusEnum.stopped:
+                        print(f"[LOG] 다운로드 정지됨, 파싱 중단: {req.id}")
+                        return
+
+                    proxy_addr = await proxy_manager.get_next_available_proxy(db, req.id)
+                    if not proxy_addr:
+                        raise Exception("모든 프록시 시도 실패")
+                    proxies = _build_proxy_dict(proxy_addr)
+
+                    # Throttle SSE frequency (every 50, or every 10 seconds)
+                    if self.should_send_sse(req.id, retry_count + 1):
+                        total_failed_count = await proxy_manager.get_total_failed_count(db)
+                        await sse_manager.broadcast_message("proxy_trying", {
+                            "id": req.id,
+                            "proxy": proxy_addr,
+                            "step": "파싱",
+                            "current": retry_count + 1,
+                            "total": total_proxies,
+                            "failed": total_failed_count,
+                        })
+                        print(f"[LOG] SSE 파싱시도 전송: {retry_count + 1}/{total_proxies}")
+
+                    try:
+                        parse_result = await asyncio.wait_for(
+                            loop.run_in_executor(
+                                None,
+                                lambda p=proxies: parse_special_hoster_sync(
+                                    req.url, req.password, proxies=p
+                                ),
+                            ),
+                            timeout=SPECIAL_HOSTER_PARSE_TIMEOUT_SEC,
+                        )
+                        if parse_result:
+                            break
+                    except asyncio.TimeoutError:
+                        await proxy_manager.mark_proxy_failed(db, proxy_addr)
+                        retry_count += 1
+                        continue
+                    except Exception as e:
+                        print(f"[LOG] 프록시 파싱 실패 {proxy_addr}: {e}")
+                        await proxy_manager.mark_proxy_failed(db, proxy_addr)
+                        retry_count += 1
+                        if retry_count >= MAX_RETRIES:
+                            raise
+                        continue
+
+                if not parse_result:
+                    raise Exception(
+                        f"프록시 파싱 실패 - 최대 재시도({MAX_RETRIES}) 초과"
+                    )
 
             file_info = parse_result.get("file_info") or {}
             if _should_replace_file_name(req.file_name, file_info.get("name")):

--- a/backend/core/hoster_parsers.py
+++ b/backend/core/hoster_parsers.py
@@ -145,13 +145,15 @@ def _format_size_bytes(num_bytes: int) -> str:
     return f"{num_bytes} B"
 
 
-def _scraper():
+def _scraper(proxies: Optional[Dict[str, str]] = None):
     scraper = cloudscraper.create_scraper()
     scraper.headers.update({
         "User-Agent": DEFAULT_HOSTER_USER_AGENT,
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
     })
+    if proxies:
+        scraper.proxies.update(proxies)
     return scraper
 
 
@@ -186,12 +188,17 @@ def _flaresolverr_request_get(
     session_id: str = "",
     referer: str = "",
     max_timeout_ms: int = FLARESOLVERR_MAX_TIMEOUT_MS,
+    proxies: Optional[Dict[str, str]] = None,
 ) -> Optional[dict]:
     payload = {
         "cmd": "request.get",
         "url": url,
         "maxTimeout": max_timeout_ms,
     }
+    if proxies:
+        proxy_url = proxies.get("https") or proxies.get("http")
+        if proxy_url:
+            payload["proxy"] = {"url": proxy_url}
     if session_id:
         payload["session"] = session_id
     if referer:
@@ -226,7 +233,9 @@ def _solution_cookies(solution: Optional[dict]) -> Dict[str, str]:
     return cookies
 
 
-def get_flaresolverr_context_for_url(url: str, referer: str = "") -> Dict[str, object]:
+def get_flaresolverr_context_for_url(
+    url: str, referer: str = "", proxies: Optional[Dict[str, str]] = None
+) -> Dict[str, object]:
     """Use FlareSolverr to obtain Cloudflare cookies and browser context.
 
     Important: this visits only the origin root, not the large file URL itself,
@@ -236,7 +245,7 @@ def get_flaresolverr_context_for_url(url: str, referer: str = "") -> Dict[str, o
     if not parsed.scheme or not parsed.netloc:
         return {"cookies": {}, "user_agent": None}
     origin = f"{parsed.scheme}://{parsed.netloc}/"
-    solution = _flaresolverr_request_get(origin, referer=referer)
+    solution = _flaresolverr_request_get(origin, referer=referer, proxies=proxies)
     if not solution:
         return {"cookies": {}, "user_agent": None}
     return {
@@ -255,8 +264,10 @@ def _response_text(response) -> str:
     return getattr(response, "text", "") or ""
 
 
-def _get_page_with_flaresolverr(url: str, referer: str = "") -> Optional[tuple[str, Dict[str, str], str]]:
-    solution = _flaresolverr_request_get(url, referer=referer)
+def _get_page_with_flaresolverr(
+    url: str, referer: str = "", proxies: Optional[Dict[str, str]] = None
+) -> Optional[tuple[str, Dict[str, str], str]]:
+    solution = _flaresolverr_request_get(url, referer=referer, proxies=proxies)
     if not solution:
         return None
     return (
@@ -378,9 +389,10 @@ def _resolve_megaup_final_link(
     referer: str,
     cookies: Dict[str, str],
     user_agent: str,
+    proxies: Optional[Dict[str, str]] = None,
 ) -> tuple[str, Dict[str, str], str, str]:
     """Follow MegaUp's intermediate download page to the tokenized file URL."""
-    fs_context = get_flaresolverr_context_for_url(download_link, referer=referer)
+    fs_context = get_flaresolverr_context_for_url(download_link, referer=referer, proxies=proxies)
     merged_cookies = {**cookies, **(fs_context.get("cookies") or {})}
     browser_ua = fs_context.get("user_agent") or user_agent
     headers = {
@@ -397,6 +409,7 @@ def _resolve_megaup_final_link(
             timeout=30,
             allow_redirects=True,
             stream=True,
+            proxies=proxies,
         )
     except Exception as exc:
         print(f"[WARNING] MegaUp 최종 링크 확인 실패: {exc}")
@@ -416,13 +429,13 @@ def _resolve_megaup_final_link(
     return final_link, merged_cookies, browser_ua, response.url or download_link
 
 
-def parse_megaup_sync(url: str) -> Dict[str, object]:
-    scraper = _scraper()
+def parse_megaup_sync(url: str, proxies: Optional[Dict[str, str]] = None) -> Dict[str, object]:
+    scraper = _scraper(proxies)
     response = scraper.get(url, timeout=30)
     text = _response_text(response)
     fs_cookies: Dict[str, str] = {}
     if _cloudflare_challenge_seen(response, text):
-        fs_page = _get_page_with_flaresolverr(url)
+        fs_page = _get_page_with_flaresolverr(url, proxies=proxies)
         if fs_page:
             text, fs_cookies, url = fs_page
     _raise_for_dead_page("MegaUp", text, getattr(response, "status_code", 0))
@@ -440,6 +453,7 @@ def parse_megaup_sync(url: str) -> Dict[str, object]:
         referer=referer,
         cookies=cookies,
         user_agent=user_agent,
+        proxies=proxies,
     )
 
     return HosterParseResult(
@@ -561,15 +575,15 @@ def _extract_datanodes_countdown_payload(html_text: str, file_code: str) -> Dict
     return payload
 
 
-def parse_datanodes_sync(url: str) -> Dict[str, object]:
+def parse_datanodes_sync(url: str, proxies: Optional[Dict[str, str]] = None) -> Dict[str, object]:
     file_code, filename = _parse_datanodes_url(url)
-    scraper = _scraper()
+    scraper = _scraper(proxies)
 
     page_response = scraper.get(url, timeout=30, allow_redirects=True)
     page_text = _response_text(page_response)
     fs_cookies: Dict[str, str] = {}
     if _cloudflare_challenge_seen(page_response, page_text):
-        fs_page = _get_page_with_flaresolverr(url)
+        fs_page = _get_page_with_flaresolverr(url, proxies=proxies)
         if fs_page:
             page_text, fs_cookies, url = fs_page
     _raise_for_dead_page("DataNodes", page_text, getattr(page_response, "status_code", 0))
@@ -637,12 +651,12 @@ def parse_datanodes_sync(url: str) -> Dict[str, object]:
     ).as_parse_result()
 
 
-def parse_rapidgator_constraints_sync(url: str) -> Dict[str, object]:
-    scraper = _scraper()
+def parse_rapidgator_constraints_sync(url: str, proxies: Optional[Dict[str, str]] = None) -> Dict[str, object]:
+    scraper = _scraper(proxies)
     response = scraper.get(url, timeout=30)
     text = _response_text(response)
     if _cloudflare_challenge_seen(response, text):
-        fs_page = _get_page_with_flaresolverr(url)
+        fs_page = _get_page_with_flaresolverr(url, proxies=proxies)
         if fs_page:
             text, _, url = fs_page
     _raise_for_dead_page("Rapidgator", text, getattr(response, "status_code", 0))
@@ -670,9 +684,11 @@ def _gofile_content_id(url: str) -> str:
     return match.group(1) if match else ""
 
 
-def _gofile_session() -> requests.Session:
+def _gofile_session(proxies: Optional[Dict[str, str]] = None) -> requests.Session:
     session = requests.Session()
     session.headers.update({"User-Agent": DEFAULT_HOSTER_USER_AGENT})
+    if proxies:
+        session.proxies.update(proxies)
     return session
 
 
@@ -742,12 +758,12 @@ def _gofile_result(node: Dict[str, object], token: str) -> Dict[str, object]:
     ).as_parse_result()
 
 
-def parse_gofile_sync(url: str) -> Dict[str, object]:
+def parse_gofile_sync(url: str, proxies: Optional[Dict[str, str]] = None) -> Dict[str, object]:
     content_id = _gofile_content_id(url)
     if not content_id:
         raise HosterParseError("Gofile 링크에서 콘텐츠 ID를 찾을 수 없음")
 
-    session = _gofile_session()
+    session = _gofile_session(proxies)
     token = _gofile_guest_token(session)
     if not token:
         raise HosterParseError("Gofile 게스트 토큰 발급 실패")
@@ -768,10 +784,10 @@ def parse_gofile_sync(url: str) -> Dict[str, object]:
     return _gofile_result(node, token)
 
 
-def parse_blocked_hoster_sync(url: str) -> Dict[str, object]:
+def parse_blocked_hoster_sync(url: str, proxies: Optional[Dict[str, str]] = None) -> Dict[str, object]:
     host = _host(url)
     if "send.now" in host:
-        fs_page = _get_page_with_flaresolverr(url)
+        fs_page = _get_page_with_flaresolverr(url, proxies=proxies)
         if not fs_page:
             raise HosterParseError(
                 "Send.now는 Cloudflare 챌린지로 인해 브라우저 세션 없이 자동 다운로드를 지원하지 않음"
@@ -796,17 +812,19 @@ def parse_blocked_hoster_sync(url: str) -> Dict[str, object]:
     raise HosterParseError("지원하지 않는 호스팅 사이트")
 
 
-def parse_special_hoster_sync(url: str, password: Optional[str] = None) -> Dict[str, object]:
+def parse_special_hoster_sync(
+    url: str, password: Optional[str] = None, proxies: Optional[Dict[str, str]] = None
+) -> Dict[str, object]:
     """Resolve a special host page into the download-core parse_result shape."""
     host = _host(url)
     if host in {"megaup.net", "www.megaup.net"}:
-        return parse_megaup_sync(url)
+        return parse_megaup_sync(url, proxies=proxies)
     if host in {"datanodes.to", "www.datanodes.to"}:
-        return parse_datanodes_sync(url)
+        return parse_datanodes_sync(url, proxies=proxies)
     if host in {"rapidgator.net", "www.rapidgator.net"}:
-        return parse_rapidgator_constraints_sync(url)
+        return parse_rapidgator_constraints_sync(url, proxies=proxies)
     if host in {"gofile.io", "www.gofile.io"}:
-        return parse_gofile_sync(url)
+        return parse_gofile_sync(url, proxies=proxies)
     if host in {"send.now", "www.send.now"}:
-        return parse_blocked_hoster_sync(url)
+        return parse_blocked_hoster_sync(url, proxies=proxies)
     raise HosterParseError("지원하지 않는 호스팅 사이트")

--- a/backend/tests/test_hoster_parsers.py
+++ b/backend/tests/test_hoster_parsers.py
@@ -83,14 +83,14 @@ def test_megaup_resolver_follows_download_token_page(monkeypatch):
         def close(self):
             pass
 
-    def fake_get(url, headers, cookies, timeout, allow_redirects, stream):
+    def fake_get(url, headers, cookies, timeout, allow_redirects, stream, proxies=None):
         captured.update({"url": url, "headers": headers, "cookies": cookies, "stream": stream})
         return _Resp()
 
     monkeypatch.setattr(
         hp,
         "get_flaresolverr_context_for_url",
-        lambda url, referer="": {"cookies": {"cf_clearance": "ok"}, "user_agent": "Chrome/142"},
+        lambda url, referer="", proxies=None: {"cookies": {"cf_clearance": "ok"}, "user_agent": "Chrome/142"},
     )
     monkeypatch.setattr(hp.requests, "get", fake_get)
 
@@ -226,7 +226,7 @@ def test_blocked_hosts_are_identified():
 
 
 def _patch_gofile_tokens(monkeypatch):
-    monkeypatch.setattr(hp, "_gofile_session", lambda: object())
+    monkeypatch.setattr(hp, "_gofile_session", lambda proxies=None: object())
     monkeypatch.setattr(hp, "_gofile_guest_token", lambda session: "guest-tok")
     monkeypatch.setattr(hp, "_gofile_website_token", lambda session: "test-wt")
 
@@ -310,7 +310,7 @@ def test_gofile_contents_call_includes_wt_and_web_params(monkeypatch):
             captured["headers"] = headers
             return _Resp()
 
-    monkeypatch.setattr(hp, "_gofile_session", lambda: _Sess())
+    monkeypatch.setattr(hp, "_gofile_session", lambda proxies=None: _Sess())
     monkeypatch.setattr(hp, "_gofile_guest_token", lambda session: "guest-tok")
     monkeypatch.setattr(hp, "_gofile_website_token", lambda session: "wt-123")
 
@@ -413,7 +413,7 @@ def test_sendnow_uses_flaresolverr_page_when_available(monkeypatch):
     monkeypatch.setattr(
         hp,
         "_get_page_with_flaresolverr",
-        lambda url, referer="": (html, {"cf_clearance": "ok"}, url),
+        lambda url, referer="", proxies=None: (html, {"cf_clearance": "ok"}, url),
     )
 
     result = hp.parse_special_hoster_sync("https://send.now/abc")
@@ -434,8 +434,81 @@ def test_sendnow_turnstile_is_reported_after_flaresolverr(monkeypatch):
     monkeypatch.setattr(
         hp,
         "_get_page_with_flaresolverr",
-        lambda url, referer="": (html, {"cf_clearance": "ok"}, url),
+        lambda url, referer="", proxies=None: (html, {"cf_clearance": "ok"}, url),
     )
 
     with pytest.raises(hp.HosterParseError, match="Turnstile 검증 필요"):
         hp.parse_special_hoster_sync("https://send.now/abc")
+
+
+# --- proxy threading (use_proxy parses through a user proxy) ---
+
+
+def test_gofile_session_applies_proxies():
+    proxies = {"http": "http://1.2.3.4:8080", "https": "http://1.2.3.4:8080"}
+    session = hp._gofile_session(proxies)
+    assert session.proxies.get("https") == "http://1.2.3.4:8080"
+    assert session.proxies.get("http") == "http://1.2.3.4:8080"
+
+
+def test_gofile_session_without_proxies_is_unset():
+    session = hp._gofile_session()
+    assert not session.proxies
+
+
+def test_flaresolverr_payload_includes_proxy(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"status": "ok", "solution": {}}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["payload"] = json
+        return _Resp()
+
+    monkeypatch.setattr(hp.requests, "post", fake_post)
+
+    proxies = {"http": "http://9.9.9.9:3128", "https": "http://9.9.9.9:3128"}
+    hp._flaresolverr_request_get("https://example.com", proxies=proxies)
+
+    assert captured["payload"]["proxy"] == {"url": "http://9.9.9.9:3128"}
+
+
+def test_flaresolverr_payload_omits_proxy_when_none(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"status": "ok", "solution": {}}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["payload"] = json
+        return _Resp()
+
+    monkeypatch.setattr(hp.requests, "post", fake_post)
+
+    hp._flaresolverr_request_get("https://example.com")
+
+    assert "proxy" not in captured["payload"]
+
+
+def test_special_hoster_forwards_proxies_to_gofile(monkeypatch):
+    seen = {}
+
+    def fake_gofile(url, proxies=None):
+        seen["proxies"] = proxies
+        return {"download_link": "https://store.gofile.io/x", "file_info": None}
+
+    monkeypatch.setattr(hp, "parse_gofile_sync", fake_gofile)
+
+    proxies = {"http": "http://7.7.7.7:80", "https": "http://7.7.7.7:80"}
+    hp.parse_special_hoster_sync("https://gofile.io/d/abc", proxies=proxies)
+
+    assert seen["proxies"] == proxies


### PR DESCRIPTION
## 배경

GoFile/DataNodes/MegaUp/Rapidgator/Send.now 파싱은 **프록시를 전혀 타지 않았음.** 그래서 사용자가 프록시 모드를 의도적으로 켜도 IP 차단되는 단계(예: GoFile `/contents` listing)가 항상 서버(데이터센터) IP로 나가 실패했음.

요청대로 **공통 액션**으로 처리: 프록시를 켰을 때만 special hoster 파싱 체인 전체가 프록시를 타고 실패 시 재시도. **프록시 OFF면 기존과 100% 동일.**

## 변경

**`core/hoster_parsers.py`** — 모든 요청 지점에 `proxies: Optional[Dict[str,str]]` 전달:
- `_scraper` (cloudscraper), `_gofile_session` (requests.Session) → 세션에 proxies 설정
- `_flaresolverr_request_get` → FlareSolverr payload에 `proxy.url` 추가 (DataNodes/MegaUp/Send.now)
- `_get_page_with_flaresolverr`, `get_flaresolverr_context_for_url`, `_resolve_megaup_final_link`
- 모든 `parse_*_sync` + 디스패처 `parse_special_hoster_sync`

**`core/download_core.py`** — `_download_special_hoster_async`가 `use_proxy`로 분기:
- OFF → 기존 단일 파싱 경로 그대로 (타임아웃 처리 포함)
- ON → `proxy_manager` 프록시를 순회하며 파싱, 실패 시 `mark_proxy_failed` + 다음 프록시 재시도 (`MAX_DOWNLOAD_RETRIES_PROXY_CAP` 한도). 다운로드 단계는 직결 유지.

## 테스트
- [x] 신규 단위 테스트 5개: gofile 세션 proxies 적용/미적용, FlareSolverr payload proxy 포함/제외, 디스패처 proxies 포워딩
- [x] 전체 469 passed, 1 skipped, 1 xpassed
- [ ] 실제 프록시(주거용) 환경에서 GoFile end-to-end 통과 확인 권장

NOTE: 다운로드 단계는 직결 유지 (GoFile 다운로드 서버는 IP 차단 없음). DataNodes/MegaUp 최종 파일 서버가 IP 제한을 건다면 후속으로 다운로드 프록시도 검토.