### PR TITLE
fix(docker): tzdata 설치로 TZ 적용 — 기간 검색 9시간 어긋남 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,12 @@ ARG VERSION=dev
 WORKDIR /app
 
 # 시스템 패키지 설치 최적화 (단일 레이어)
+# tzdata 필수: python:3.11-slim 에는 zoneinfo 가 없어 TZ=Asia/Seoul 이 해석되지
+# 않고 datetime.now() 가 UTC 로 폴백된다. 그러면 requested_at 이 UTC 로 저장되어
+# 프론트가 보내는 로컬(KST) 기간 경계와 9시간 어긋나 기간 검색이 깨진다.
 RUN apt-get update && apt-get install -y \
     curl \
+    tzdata \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
## 증상
기간/날짜 범위 검색이 정상 동작하지 않음 (오늘 추가한 항목이 안 나오거나 엉뚱한 날짜로 분류). 개발 환경에선 재현 안 됨.

## 근본 원인
백엔드 이미지 베이스가 `python:3.11-slim`인데 **`tzdata` 미설치**. slim 이미지엔 zoneinfo가 없어 `TZ=Asia/Seoul`을 glibc가 해석하지 못하고 `datetime.now()`가 **UTC로 폴백**.

→ `requested_at = datetime.now()`이 컨테이너에서 **UTC로 저장**됨.
→ 프론트엔드는 사용자 **로컬(KST) 날짜**로 기간 경계를 만들어 전송 (코드 주석도 로컬 저장 전제).
→ UTC 저장값 vs KST 경계가 **9시간 어긋나** 기간 검색이 깨짐.

개발은 호스트 직접 실행(KST + tzdata 존재)이라 정상이었고, 컨테이너(NAS) 배포에서만 발생.

## 수정
backend 이미지 apt 설치에 `tzdata` 추가. 런타임에 export되는 `TZ=Asia/Seoul`과 결합해 `datetime.now()`가 로컬시간(KST)을 반환 → 기존 기간 필터 로직이 그대로 정상 동작.

## 적용
- `docker-build.yml`이 main push 시 `latest` 재빌드 → NAS에서 `docker compose pull && up -d`로 재pull하면 반영.

## 주의
이 수정 이전에 저장된 행은 UTC로 기록돼 있어, 재배포 후 생성되는 행만 로컬시간 사용 (구 데이터는 표시/필터가 9h 시프트 — 개인 도구 수준에서 경미).