### PR TITLE
feat(1fichier): Cloudflare 차단 시 FlareSolverr 폴백

### DIFF
--- a/backend/core/simple_parser.py
+++ b/backend/core/simple_parser.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse, urlunparse
 from services.notification_service import send_telegram_wait_notification
 from core.config import CONFIG_DIR
 from core import cancel_signal
+from core.hoster_parsers import get_flaresolverr_context_for_url
 
 
 def _save_parse_debug(stage: str, status_code, body_text):
@@ -280,6 +281,31 @@ def is_likely_download_url(candidate, base_host=None):
 MAX_WAIT_SECONDS = 30 * 60
 
 
+# Markers of an unsolved Cloudflare challenge page/response.
+_CLOUDFLARE_MARKERS = (
+    "attention required! | cloudflare",
+    "checking your browser before accessing",
+    "just a moment",
+    "challenge-platform",
+    "cf_chl",
+    "cf-turnstile",
+)
+
+
+def _is_cloudflare_block(response) -> bool:
+    """True if cloudscraper failed to pass a Cloudflare challenge.
+
+    Covers both the non-200 challenge (403/503 + body markers / cf-mitigated
+    header) and the 200-but-challenge-body case, so the caller can fall back to
+    FlareSolverr before raising.
+    """
+    headers = getattr(response, "headers", {}) or {}
+    if str(headers.get("cf-mitigated", "")).lower() == "challenge":
+        return True
+    body = (getattr(response, "text", "") or "").lower()
+    return any(marker in body for marker in _CLOUDFLARE_MARKERS)
+
+
 def parse_1fichier_simple_sync(url, password=None, proxies=None, proxy_addr=None, download_id=None, sse_callback=None,
                                account_cookies=None):
     """
@@ -340,6 +366,30 @@ def parse_1fichier_simple_sync(url, password=None, proxies=None, proxy_addr=None
 
         # Always save the GET response for debugging (so the flow is traceable even on success)
         _save_parse_debug("get", response.status_code, response.text)
+
+        # Cloudflare fallback: cloudscraper alone often can't pass modern CF
+        # challenges. If the response looks like an unsolved challenge, obtain
+        # cf_clearance cookies via FlareSolverr (a real browser) once, inject
+        # them into the scraper, and retry the GET before giving up.
+        if _is_cloudflare_block(response):
+            print(f"[LOG] 1fichier Cloudflare 차단 감지 → FlareSolverr 폴백 시도")
+            cf_context = get_flaresolverr_context_for_url(url, referer=url, proxies=proxies)
+            cf_cookies = cf_context.get("cookies") or {}
+            if cf_cookies:
+                for name, value in cf_cookies.items():
+                    try:
+                        scraper.cookies.set(name, value, domain=".1fichier.com")
+                    except Exception:
+                        pass
+                cf_ua = cf_context.get("user_agent")
+                if cf_ua:
+                    headers['User-Agent'] = cf_ua
+                print(f"[LOG] FlareSolverr 쿠키 확보({list(cf_cookies.keys())}), 페이지 재요청")
+                response = scraper.get(url, headers=headers, proxies=proxies, timeout=timeout_val)
+                print(f"[DEBUG] FlareSolverr 폴백 후 응답 코드: {response.status_code}")
+                _save_parse_debug("get_cf_retry", response.status_code, response.text)
+            else:
+                print(f"[WARNING] FlareSolverr 쿠키 확보 실패 — Cloudflare 우회 불가")
 
         if response.status_code != 200:
             print(f"[ERROR] 페이지 로드 실패 - 응답 내용: {response.text[:500]}")

--- a/backend/tests/test_simple_parser_extra.py
+++ b/backend/tests/test_simple_parser_extra.py
@@ -158,6 +158,112 @@ def test_parse_simple_sync_returns_none_when_stopped_during_wait(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Cloudflare → FlareSolverr fallback
+# ---------------------------------------------------------------------------
+
+
+class _FakeCookieJar(list):
+    """List-backed cookie jar that also supports the requests ``set`` API."""
+
+    def set(self, name, value, domain=None):
+        cookie = MagicMock()
+        cookie.name = name
+        cookie.value = value
+        self.append(cookie)
+
+
+class TestIsCloudflareBlock:
+    def test_detects_cf_mitigated_header(self):
+        resp = MagicMock()
+        resp.headers = {"cf-mitigated": "challenge"}
+        resp.text = ""
+        assert sp._is_cloudflare_block(resp) is True
+
+    def test_detects_challenge_body(self):
+        resp = MagicMock()
+        resp.headers = {}
+        resp.text = "<html><title>Just a moment...</title>cf_chl</html>"
+        assert sp._is_cloudflare_block(resp) is True
+
+    def test_normal_page_is_not_a_block(self):
+        resp = MagicMock()
+        resp.headers = {}
+        resp.text = "<html><body>file.bin</body></html>"
+        assert sp._is_cloudflare_block(resp) is False
+
+
+def test_cloudflare_block_falls_back_to_flaresolverr(monkeypatch):
+    """A CF challenge on the first GET triggers a FlareSolverr cookie fetch and a retry."""
+    cf_response = MagicMock()
+    cf_response.status_code = 403
+    cf_response.text = "<html><title>Just a moment...</title></html>"
+    cf_response.headers = {"cf-mitigated": "challenge"}
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.text = _make_wait_page_html(30)
+    ok_response.headers = {}
+
+    post_response = MagicMock()
+    post_response.status_code = 302
+    post_response.text = ""
+    post_response.headers = {"Location": "https://a-2.1fichier.com/p1/file.bin"}
+
+    scraper = MagicMock()
+    scraper.cookies = _FakeCookieJar()
+    scraper.get.side_effect = [cf_response, ok_response]
+    scraper.post.return_value = post_response
+
+    monkeypatch.setattr(sp.cloudscraper, "create_scraper", lambda **kw: scraper)
+    monkeypatch.setattr(sp.time, "sleep", lambda s: None)
+
+    fs_calls = []
+
+    def fake_fs(url, referer="", proxies=None):
+        fs_calls.append(url)
+        return {"cookies": {"cf_clearance": "tok"}, "user_agent": "Chrome/142"}
+
+    monkeypatch.setattr(sp, "get_flaresolverr_context_for_url", fake_fs)
+
+    result = sp.parse_1fichier_simple_sync(
+        "https://1fichier.com/?abc",
+        password=None, proxies=None, proxy_addr=None,
+        download_id=None, sse_callback=None,
+    )
+
+    assert fs_calls, "FlareSolverr fallback was not invoked on a CF block"
+    assert scraper.get.call_count == 2, "GET was not retried after obtaining CF cookies"
+    assert result["download_link"].startswith("https://a-2.1fichier.com/")
+
+
+def test_cloudflare_block_without_fs_cookies_does_not_retry(monkeypatch):
+    """If FlareSolverr yields no cookies, no retry happens and the CF block surfaces."""
+    cf_response = MagicMock()
+    cf_response.status_code = 403
+    cf_response.text = "<html><title>Attention Required! | Cloudflare</title></html>"
+    cf_response.headers = {}
+
+    scraper = MagicMock()
+    scraper.cookies = _FakeCookieJar()
+    scraper.get.return_value = cf_response
+
+    monkeypatch.setattr(sp.cloudscraper, "create_scraper", lambda **kw: scraper)
+    monkeypatch.setattr(
+        sp, "get_flaresolverr_context_for_url",
+        lambda url, referer="", proxies=None: {"cookies": {}, "user_agent": None},
+    )
+
+    with pytest.raises(Exception):
+        sp.parse_1fichier_simple_sync(
+            "https://1fichier.com/?abc",
+            password=None, proxies=None, proxy_addr=None,
+            download_id=None, sse_callback=None,
+        )
+
+    assert scraper.get.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # extract_file_info_simple — additional patterns
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 배경
1fichier 파싱은 cloudscraper 단독이고 FlareSolverr 폴백이 없었음 (파싱·다운로드 양쪽). 그래서 cloudscraper가 못 뚫는 Cloudflare 챌린지가 걸리면 5분 뒤 재시도해도 똑같이 cloudscraper로만 재시도 → 사실상 안 풀림. special hoster는 이미 cloudscraper→FlareSolverr 폴백이 있어서 1fichier도 맞춤.

## 변경 (`core/simple_parser.py`)
- `_is_cloudflare_block(response)` 추가: `cf-mitigated: challenge` 헤더 또는 챌린지 본문 마커(just a moment / cf_chl / challenge-platform 등) 감지. 비200(403/503) + 200-챌린지 본문 모두 커버.
- 첫 cloudscraper GET 직후 CF 감지 시 `get_flaresolverr_context_for_url(url, proxies=proxies)`로 cf_clearance 쿠키+UA 확보 → 스크래퍼에 주입 → GET 1회 재시도. 쿠키 못 받으면 기존 CF 에러로 폴스루.
- 프록시 모드면 FlareSolverr도 동일 프록시 사용 (PR #32 인프라 재사용).

## 테스트
- [x] `_is_cloudflare_block` 단위(헤더/본문/정상)
- [x] CF 감지 → FlareSolverr 호출 + GET 재시도 후 성공
- [x] FlareSolverr 쿠키 없으면 재시도 안 하고 CF 에러
- [x] 전체 474 passed

NOTE: FlareSolverr 서비스가 떠 있어야 동작 (compose에 포함). 미동작 시 쿠키 확보 실패 → 기존과 동일하게 CF 실패.