### PR TITLE
fix(ui): 기간 필터를 목록에도 적용 (전체=30일 동일 문제)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -537,6 +537,26 @@
     }
   }
 
+  // Filter a download list by the currently selected period. Used by the main
+  // grid so the list — not only the dashboard charts — respects the period bar.
+  // Compares each item's added date (created_at == requested_at). Items without
+  // a parseable date are kept rather than hidden.
+  function filterByPeriod(list) {
+    const { start, end } = getDashboardDateRange();
+    if (!start && !end) return list;
+    const startMs = start ? new Date(start + "T00:00:00").getTime() : null;
+    const endMs = end ? new Date(end + "T23:59:59.999").getTime() : null;
+    return list.filter((d) => {
+      const ds = d.created_at || d.finished_at;
+      if (!ds) return true;
+      const t = new Date(ds).getTime();
+      if (Number.isNaN(t)) return true;
+      if (startMs !== null && t < startMs) return false;
+      if (endMs !== null && t > endMs) return false;
+      return true;
+    });
+  }
+
   async function fetchDashboardStats() {
     try {
       const { start, end } = getDashboardDateRange();
@@ -1864,16 +1884,23 @@
   let workingCount = 0;
   let completedCount = 0;
   $: {
+    // Recompute when the period (or its custom dates) changes too — the list,
+    // not only the dashboard charts, must respect the period bar.
+    dashboardPeriod;
+    dashboardStartDate;
+    dashboardEndDate;
     if (!Array.isArray(downloads)) {
       workingCount = 0;
       completedCount = 0;
       filteredDownloads = [];
     } else {
-      // Step 1: apply the search filter
-      let filtered = downloads;
+      // Step 1: apply the period date-range filter (matches the period bar above)
+      let filtered = filterByPeriod(downloads);
+
+      // Step 2: apply the search filter
       if (searchQuery && searchQuery.trim()) {
         const query = searchQuery.trim().toLowerCase();
-        filtered = downloads.filter((d) => {
+        filtered = filtered.filter((d) => {
           const filename = d.filename?.toLowerCase() || "";
           const url = d.url?.toLowerCase() || "";
           return filename.includes(query) || url.includes(query);


### PR DESCRIPTION
## 증상
기간 바에서 30일 ↔ 전체를 바꿔도 **다운로드 목록이 동일**.

## 원인
기간 바(`dashboardPeriod`)는 상단 대시보드 차트(`dashboardHistory`/`dashboardStats`)만 갱신. 정작 아래 목록 그리드가 쓰는 `filteredDownloads`는 라이브 `downloads`를 **검색+탭으로만** 거르고 **기간을 전혀 안 봄**. (백엔드 `/history/period` 필터 자체는 정상 — 합성 데이터로 검증함.)

## 수정 (`frontend/src/App.svelte`)
- `filterByPeriod()` 헬퍼 추가: 각 항목의 `created_at`(=requested_at, "추가한 날짜")을 `getDashboardDateRange()` 범위와 비교. 날짜 파싱 안 되는 항목은 숨기지 않고 유지.
- `filteredDownloads` 계산의 첫 단계로 기간 필터 적용 + `dashboardPeriod/startDate/endDate`를 반응형 의존성에 추가 → 기간 변경 시 목록 재계산.

## 검증
- [x] 프론트 빌드 성공
- [x] 백엔드 기간 필터 로직 합성 데이터 검증(60일 전 항목은 30d 제외, all 포함)

## 한계 (별개)
라이브 목록은 `/api/history/`의 최근 200개라, 200개 넘는 "전체"는 여전히 200개로 bounded. 필요하면 서버 페이지네이션 연동은 후속.