### PR TITLE
fix(history): '전체' cap 제거 — limit 미지정 시 모든 행 반환

### DIFF
--- a/backend/api/routes/history.py
+++ b/backend/api/routes/history.py
@@ -31,7 +31,12 @@ async def get_download_history(
     limit: Optional[int] = None,
     offset: int = 0
 ):
-    """Get download history (default limit=200)"""
+    """Get download history.
+
+    ``limit=None`` (default) and ``limit<=0`` return all rows — the UI's "전체"
+    view should actually mean everything, not a silent 200-item cap. Pass an
+    explicit positive ``limit`` to cap the response.
+    """
     try:
         # Fetch recent downloads (descending by ID)
         base_query = db.query(DownloadRequest).order_by(desc(DownloadRequest.id))
@@ -39,15 +44,13 @@ async def get_download_history(
         # Total count (before applying offset/limit)
         total_count = base_query.count()
 
-        # Default limit=200
-        effective_limit = limit if limit is not None else 200
-
-        # Apply offset if present
+        # Apply offset and optional limit
         query = base_query
         if offset > 0:
             query = query.offset(offset)
+        if limit is not None and limit > 0:
+            query = query.limit(limit)
 
-        query = query.limit(effective_limit)
         downloads = query.all()
 
         history = []


### PR DESCRIPTION
## 변경
`/api/history/`가 limit 미지정 시 조용히 200개로 잘랐던 동작을 제거. `limit=None`(기본) 또는 `limit<=0`이면 전체 반환, 양수면 명시 cap.

## 영향
- 프론트는 파라미터 없이 호출 중이라 별도 수정 없이 **전체 목록**을 받게 됨.
- 200개 초과 사용자도 "전체" 선택 시 실제로 다 표시.
- 명시 cap이 필요하면 `?limit=N`으로 전달 가능.

## 검증
- [x] 전체 477 passed