### PR TITLE
fix(ux): 완료된 행에서 옛 실패 잔여 제거 + 재시도 대기 라벨 통일

### DIFF
--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -104,6 +104,22 @@ TASK_CANCEL_TIMEOUT_SEC = 1.0
 SPECIAL_HOSTER_PARSE_TIMEOUT_SEC = 300  # 5 minutes
 
 
+def _clear_failure_metadata(req) -> None:
+    """On a successful completion, wipe leftover failure flags so the row no
+    longer carries a stale ``error`` / ``failure_kind`` / ``next_retry_at`` /
+    ``attempt_count`` into the 완료됨 tab. Retries that succeed shouldn't keep
+    dragging the old failure label, tooltip text, or cooldown countdown.
+    ``hasattr`` guards keep this safe on older schema versions.
+    """
+    req.error = None
+    if hasattr(req, "failure_kind"):
+        req.failure_kind = None
+    if hasattr(req, "next_retry_at"):
+        req.next_retry_at = None
+    if hasattr(req, "attempt_count"):
+        req.attempt_count = 0
+
+
 def _build_proxy_dict(proxy_addr: Optional[str]) -> Optional[Dict[str, str]]:
     """Convert ``proxy_addr`` (e.g. ``1.2.3.4:8080``) into the proxies dict that
     requests/aiohttp accept. Returns None if given None.
@@ -1204,6 +1220,7 @@ class DownloadCore:
         req.status = StatusEnum.done
         req.downloaded_size = downloaded_size
         req.finished_at = datetime.datetime.now()
+        _clear_failure_metadata(req)
         db.commit()
 
         await self.send_download_update(req.id, {
@@ -1587,6 +1604,7 @@ class DownloadCore:
                                 req.status = StatusEnum.done
                                 req.downloaded_size = downloaded_size
                                 req.finished_at = datetime.datetime.now()
+                                _clear_failure_metadata(req)
                                 print(f"[LOG] 상태를 done으로 변경 완료")
 
                                 db.commit()
@@ -2016,6 +2034,7 @@ class DownloadCore:
             req.status = StatusEnum.done
             req.downloaded_size = written
             req.finished_at = datetime.datetime.now()
+            _clear_failure_metadata(req)
             db.commit()
             await self.send_download_update(req.id, {
                 "status": "done", "progress": 100, "message": "다운로드 완료"

--- a/backend/locales/ar.json
+++ b/backend/locales/ar.json
@@ -11,6 +11,7 @@
   "download_done": "تم",
   "download_stopped": "متوقف",
   "download_failed": "فشل",
+  "download_retry_pending": "إعادة المحاولة قيد الانتظار",
   "download_parsing": "جارٍ التحليل",
   "download_waiting": "في الانتظار",
   "table_header_file_name": "اسم الملف",

--- a/backend/locales/de.json
+++ b/backend/locales/de.json
@@ -11,6 +11,7 @@
   "download_done": "Fertig",
   "download_stopped": "Gestoppt",
   "download_failed": "Fehlgeschlagen",
+  "download_retry_pending": "Wiederholung ausstehend",
   "download_parsing": "Wird analysiert",
   "download_waiting": "Wartet",
   "table_header_file_name": "Dateiname",

--- a/backend/locales/en.json
+++ b/backend/locales/en.json
@@ -11,6 +11,7 @@
   "download_done": "Done",
   "download_stopped": "Stopped",
   "download_failed": "Failed",
+  "download_retry_pending": "Retry pending",
   "download_parsing": "Parsing",
   "download_waiting": "Waiting",
   "table_header_file_name": "File Name",

--- a/backend/locales/es.json
+++ b/backend/locales/es.json
@@ -11,6 +11,7 @@
   "download_done": "Completado",
   "download_stopped": "Detenido",
   "download_failed": "Fallido",
+  "download_retry_pending": "Reintento pendiente",
   "download_parsing": "Analizando",
   "download_waiting": "Esperando",
   "table_header_file_name": "Nombre de archivo",

--- a/backend/locales/fr.json
+++ b/backend/locales/fr.json
@@ -11,6 +11,7 @@
   "download_done": "Terminé",
   "download_stopped": "Arrêté",
   "download_failed": "Échec",
+  "download_retry_pending": "Nouvelle tentative en attente",
   "download_parsing": "Analyse",
   "download_waiting": "En attente",
   "table_header_file_name": "Nom du fichier",

--- a/backend/locales/id.json
+++ b/backend/locales/id.json
@@ -11,6 +11,7 @@
   "download_done": "Selesai",
   "download_stopped": "Dihentikan",
   "download_failed": "Gagal",
+  "download_retry_pending": "Mencoba lagi tertunda",
   "download_parsing": "Mengurai",
   "download_waiting": "Menunggu",
   "table_header_file_name": "Nama Berkas",

--- a/backend/locales/it.json
+++ b/backend/locales/it.json
@@ -11,6 +11,7 @@
   "download_done": "Completato",
   "download_stopped": "Interrotto",
   "download_failed": "Non riuscito",
+  "download_retry_pending": "Nuovo tentativo in attesa",
   "download_parsing": "Analisi",
   "download_waiting": "In attesa",
   "table_header_file_name": "Nome file",

--- a/backend/locales/ja.json
+++ b/backend/locales/ja.json
@@ -11,6 +11,7 @@
   "download_done": "完了",
   "download_stopped": "停止",
   "download_failed": "失敗",
+  "download_retry_pending": "再試行待ち",
   "download_parsing": "解析中",
   "download_waiting": "待機中",
   "table_header_file_name": "ファイル名",

--- a/backend/locales/ko.json
+++ b/backend/locales/ko.json
@@ -11,6 +11,7 @@
   "download_done": "완료",
   "download_stopped": "정지됨",
   "download_failed": "실패",
+  "download_retry_pending": "재시도 대기",
   "download_parsing": "파싱 중",
   "download_waiting": "대기중",
   "table_header_file_name": "파일명",

--- a/backend/locales/nl.json
+++ b/backend/locales/nl.json
@@ -11,6 +11,7 @@
   "download_done": "Voltooid",
   "download_stopped": "Gestopt",
   "download_failed": "Mislukt",
+  "download_retry_pending": "Wachten op nieuwe poging",
   "download_parsing": "Bezig met parseren",
   "download_waiting": "Wachten",
   "table_header_file_name": "Bestandsnaam",

--- a/backend/locales/pl.json
+++ b/backend/locales/pl.json
@@ -11,6 +11,7 @@
   "download_done": "Gotowe",
   "download_stopped": "Zatrzymano",
   "download_failed": "Niepowodzenie",
+  "download_retry_pending": "Oczekiwanie na ponowną próbę",
   "download_parsing": "Analizowanie",
   "download_waiting": "Oczekiwanie",
   "table_header_file_name": "Nazwa pliku",

--- a/backend/locales/pt-BR.json
+++ b/backend/locales/pt-BR.json
@@ -11,6 +11,7 @@
   "download_done": "Concluído",
   "download_stopped": "Parado",
   "download_failed": "Falhou",
+  "download_retry_pending": "Nova tentativa pendente",
   "download_parsing": "Analisando",
   "download_waiting": "Aguardando",
   "table_header_file_name": "Nome do arquivo",

--- a/backend/locales/ru.json
+++ b/backend/locales/ru.json
@@ -11,6 +11,7 @@
   "download_done": "Готово",
   "download_stopped": "Остановлено",
   "download_failed": "Не удалось",
+  "download_retry_pending": "Ожидание повторной попытки",
   "download_parsing": "Анализ",
   "download_waiting": "Ожидание",
   "table_header_file_name": "Имя файла",

--- a/backend/locales/th.json
+++ b/backend/locales/th.json
@@ -11,6 +11,7 @@
   "download_done": "เสร็จสิ้น",
   "download_stopped": "หยุดแล้ว",
   "download_failed": "ล้มเหลว",
+  "download_retry_pending": "รอลองใหม่",
   "download_parsing": "กำลังแยกวิเคราะห์",
   "download_waiting": "กำลังรอ",
   "table_header_file_name": "ชื่อไฟล์",

--- a/backend/locales/tr.json
+++ b/backend/locales/tr.json
@@ -11,6 +11,7 @@
   "download_done": "Tamamlandı",
   "download_stopped": "Durduruldu",
   "download_failed": "Başarısız",
+  "download_retry_pending": "Yeniden deneme bekleniyor",
   "download_parsing": "Ayrıştırılıyor",
   "download_waiting": "Bekleniyor",
   "table_header_file_name": "Dosya Adı",

--- a/backend/locales/vi.json
+++ b/backend/locales/vi.json
@@ -11,6 +11,7 @@
   "download_done": "Hoàn tất",
   "download_stopped": "Đã dừng",
   "download_failed": "Thất bại",
+  "download_retry_pending": "Đang chờ thử lại",
   "download_parsing": "Đang phân tích",
   "download_waiting": "Đang chờ",
   "table_header_file_name": "Tên tệp",

--- a/backend/locales/zh-CN.json
+++ b/backend/locales/zh-CN.json
@@ -11,6 +11,7 @@
   "download_done": "完成",
   "download_stopped": "已停止",
   "download_failed": "失败",
+  "download_retry_pending": "等待重试",
   "download_parsing": "解析中",
   "download_waiting": "等待中",
   "table_header_file_name": "文件名",

--- a/backend/locales/zh-TW.json
+++ b/backend/locales/zh-TW.json
@@ -11,6 +11,7 @@
   "download_done": "完成",
   "download_stopped": "已停止",
   "download_failed": "失敗",
+  "download_retry_pending": "等待重試",
   "download_parsing": "解析中",
   "download_waiting": "等待中",
   "table_header_file_name": "檔案名稱",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2500,11 +2500,15 @@
                           ></span>
                         </span>
                       {:else if download.status.toLowerCase() === "failed" && download.failure_kind}
-                        <!-- On failure show a single label: the classified reason (detail in tooltip) -->
-                        {$t("kind_" + download.failure_kind)}
+                        <!-- Retry-pending failures are still part of the queue
+                             (auto-retry on cooldown). Read as "재시도 대기" + countdown
+                             so they don't look terminal. The specific kind stays
+                             visible in the detail modal / tooltip. -->
                         {#if download.next_retry_at && new Date(download.next_retry_at).getTime() > currentTime}
-                          <!-- Show the cooldown countdown so it's clear when a retry becomes possible -->
+                          {$t("download_retry_pending")}
                           <span class="wait-countdown">({formatWaitTime((new Date(download.next_retry_at).getTime() - currentTime) / 1000)})</span>
+                        {:else}
+                          {$t("kind_" + download.failure_kind)}
                         {/if}
                       {:else}
                         {$t(`download_${download.status.toLowerCase()}`)}


### PR DESCRIPTION
## 답변/배경
**탭 배치는 이미 정확**: `status==done` → 완료, 그 외 전부 → 진행중. 일시차단(=`failed`+`kind=blocked`)은 반드시 진행중. 사용자가 본 "완료됨의 일시차단"의 진짜 원인은 두 가지였음:
1. 자동 재시도 성공 후에도 `error`/`failure_kind` 컬럼이 남아 done 행이 옛 실패 메타를 끌고 다님.
2. failed + 재시도 예정 행이 "일시 차단"이라는 종결성 라벨로 떠서 큐의 한 단계가 아닌 종료된 것으로 읽힘.

## 변경
### Backend (`core/download_core.py`)
- `_clear_failure_metadata(req)` 헬퍼 추가. 성공 커밋 3곳(`_consume_response_and_finish`, `_perform_file_download_async` 성공, MEGA 성공)에서 호출해 `error`/`failure_kind`/`next_retry_at`/`attempt_count` 비움. done 행에 옛 차단 라벨/카운트다운이 끌려가지 않음.

### Frontend (`App.svelte` + locales)
- 상태 컬럼: `status=failed` + `next_retry_at` 미래면 "재시도 대기 + 카운트다운"으로 통일. 종결처럼 안 읽힘. 구체 사유는 상세 모달/툴팁 그대로.
- 신규 i18n 키 `download_retry_pending` 18개 로케일 전부 추가 (parity 통과).

## 후속 (이번엔 안 함)
모바일 좁은 화면용 행 압축 (컬럼 정리/사이즈 다듬기) — UX 따로 PR로.

## 검증
- [x] 477 passed, 1 skipped, 1 xpassed
- [x] 프론트 빌드 OK
- [x] locale parity OK