### PR TITLE
fix(ui): 모바일 그리드 행 압축 — 핵심만 남기고 가로 스크롤 제거

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2415,13 +2415,13 @@
               </th>
               <th>{$t("table_header_file_name")}</th>
               <th class="center-align">{$t("table_header_status")}</th>
-              <th class="center-align">{$t("table_header_size")}</th>
+              <th class="center-align col-size">{$t("table_header_size")}</th>
               <th class="center-align">{$t("table_header_progress")}</th>
               {#if currentTab !== "completed"}
-                <th class="center-align">{$t("table_header_speed")}</th>
+                <th class="center-align col-speed">{$t("table_header_speed")}</th>
               {/if}
-              <th class="center-align">{$t("table_header_requested_date")}</th>
-              <th class="center-align">{$t("table_header_proxy")}</th>
+              <th class="center-align col-date">{$t("table_header_requested_date")}</th>
+              <th class="center-align col-proxy">{$t("table_header_proxy")}</th>
               <th class="center-align actions-header"
                 >{$t("table_header_actions")}</th
               >
@@ -2434,13 +2434,13 @@
                   <td class="select-col"><Skeleton width="18px" height="18px" radius="5px" /></td>
                   <td><Skeleton width="80%" height="14px" radius="3px" /></td>
                   <td class="center-align"><Skeleton width="64px" height="22px" radius="10px" /></td>
-                  <td class="center-align"><Skeleton width="52px" height="14px" radius="3px" /></td>
+                  <td class="center-align col-size"><Skeleton width="52px" height="14px" radius="3px" /></td>
                   <td class="center-align"><Skeleton width="100%" height="8px" radius="4px" /></td>
                   {#if currentTab !== "completed"}
-                    <td class="center-align"><Skeleton width="52px" height="14px" radius="3px" /></td>
+                    <td class="center-align col-speed"><Skeleton width="52px" height="14px" radius="3px" /></td>
                   {/if}
-                  <td class="center-align"><Skeleton width="82px" height="14px" radius="3px" /></td>
-                  <td class="center-align"><Skeleton width="44px" height="22px" radius="10px" /></td>
+                  <td class="center-align col-date"><Skeleton width="82px" height="14px" radius="3px" /></td>
+                  <td class="center-align col-proxy"><Skeleton width="44px" height="22px" radius="10px" /></td>
                   <td class="center-align"><Skeleton width="76px" height="28px" radius="6px" /></td>
                 </tr>
               {/each}
@@ -2520,7 +2520,7 @@
                       {/if}
                     </span>
                   </td>
-                  <td class="center-align">
+                  <td class="center-align col-size">
                     {download.total_size
                       ? formatBytes(download.total_size)
                       : download.file_size || "-"}
@@ -2541,7 +2541,7 @@
                     </div>
                   </td>
                   {#if currentTab !== "completed"}
-                    <td class="center-align speed-cell">
+                    <td class="center-align speed-cell col-speed">
                       {#if download.download_speed && (download.status.toLowerCase() === "downloading" || download.status.toLowerCase() === "proxying" || download.status.toLowerCase() === "parsing")}
                         <span
                           class="speed-text {download.use_proxy
@@ -2564,12 +2564,12 @@
                     </td>
                   {/if}
                   <td
-                    class="center-align"
+                    class="center-align col-date"
                     title={formatFullDateTime(download.created_at)}
                   >
                     {formatDate(download.created_at)}
                   </td>
-                  <td class="proxy-toggle-cell">
+                  <td class="proxy-toggle-cell col-proxy">
                     <button
                       type="button"
                       class="grid-proxy-toggle {download.use_proxy

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1075,18 +1075,39 @@ select.input option {
   }
 
   .table-container {
-    overflow-x: auto; /* Enable horizontal scrolling for tables */
-    overflow-y: auto; /* Enable vertical scrolling for tables */
-    max-height: 60vh; /* 모바일에서는 60% 높이로 제한 */
+    overflow-x: hidden; /* Secondary columns are hidden below; no side-scroll needed. */
+    overflow-y: auto;
+    max-height: 60vh;
   }
 
   table {
-    width: 100%; /* Ensure table takes full width */
+    width: 100%;
+    table-layout: fixed; /* Honor the tighter widths below without runaway columns. */
   }
 
   th, td {
-    padding: 0.75rem;
+    padding: 0.5rem 0.4rem;
     font-size: 0.8rem;
+  }
+
+  /* Mobile: keep only the essentials in the row (name + status + progress +
+     actions). Size, speed, date, and the proxy toggle are still available in
+     the detail modal and on wider screens — they were squeezing the row
+     unreadably on phones. */
+  .col-size,
+  .col-speed,
+  .col-date,
+  .col-proxy {
+    display: none;
+  }
+
+  /* Filename column should truncate cleanly rather than push the row wider. */
+  table td:nth-child(2),
+  table th:nth-child(2) {
+    max-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .actions {


### PR DESCRIPTION
## 배경
기존 모바일은 8컬럼을 가로 스크롤로 흘려보내 사용자가 자주 보는 상태/진행률 열이 화면 밖으로 빠지고 행이 빡빡해 보였음 ("개같이 좁다").

## 변경 (`App.svelte` + `app.css`)
- 헤더/셀에 의미 클래스 추가: `col-size`, `col-speed`, `col-date`, `col-proxy`. 데스크톱은 기존 `center-align`을 그대로 써서 변화 없음.
- `@media (max-width: 768px)`에서 위 네 컬럼 `display: none`. 모바일 행은 **이름 + 상태 + 진행률 + 액션**만.
- 파일명 컬럼은 줄넘김 없이 ellipsis 처리(table-layout: fixed) → 행이 안 늘어남.
- `.table-container`의 `overflow-x: auto` 제거 (이제 가로 스크롤 필요 없음).

## 후속
- 부가 정보(크기/속도/날짜/프록시)는 상세 모달에서 동일하게 확인 가능. 데스크톱(>=769px)은 변화 없음.

## 검증
- [x] 477 passed
- [x] 프론트 빌드 OK