### PR TITLE
feat: smart per-host download admission + configurable concurrency (v2.2.0)

### DIFF
--- a/backend/api/routes/settings.py
+++ b/backend/api/routes/settings.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from core.config import get_config, save_config, get_download_path, get_default_download_path, IS_STANDALONE
 from core.db import get_db
 from core.version import CURRENT_VERSION
+from core.download_core import download_core
 from services.notification_service import send_telegram_notification
 
 
@@ -64,6 +65,9 @@ async def update_settings_endpoint(settings: dict, request: Request):
 
         # Save the settings
         save_config(settings)
+
+        # Apply concurrency changes to new downloads without a restart.
+        download_core.refresh_concurrency_settings()
 
         return {"success": True, "message": "설정이 저장되었습니다."}
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -72,7 +72,12 @@ DEFAULT_CONFIG = {
     "language": "ko",
     # FlareSolverr endpoint for Cloudflare-protected hosts (MegaUp/GoFile/etc.).
     # Empty → fall back to the FLARESOLVERR_URL env var, then http://localhost:8191.
-    "flaresolverr_url": ""
+    "flaresolverr_url": "",
+    # Smart-download concurrency. The global ceiling bounds total simultaneous
+    # downloads; the per-host cap keeps a few big files on one host from starving
+    # small files on another host (each host gets its own queue). See download_core.
+    "max_concurrent_downloads": 8,
+    "max_per_host_downloads": 3
 }
 
 def get_config():

--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -21,7 +21,7 @@ from typing import Optional, Dict, Any, AsyncGenerator
 from sqlalchemy.orm import Session
 
 from .models import DownloadRequest, StatusEnum
-from .config import get_download_path
+from .config import get_download_path, get_config
 from .db import SessionLocal
 from services.sse_manager import sse_manager
 from services.notification_service import send_telegram_start_notification, send_telegram_notification
@@ -77,7 +77,7 @@ FICHIER_HOST_BACKOFF_SECONDS = (120, 300, 900, 1800)  # 2m → 5m → 15m → 30
 
 # Per-site concurrent-download limits (host substring -> max concurrent).
 # Different hosts tolerate different parallelism, so each gets its own queue
-# instead of sharing one global limit. Unlisted hosts use MAX_GENERAL_DOWNLOADS.
+# instead of sharing one global limit. Unlisted hosts use MAX_PER_HOST_DOWNLOADS.
 # (1fichier local has its own dedicated semaphore — max 1 — handled separately.)
 SITE_DOWNLOAD_LIMITS = {
     "megaup.net": 2,
@@ -86,6 +86,41 @@ SITE_DOWNLOAD_LIMITS = {
     "rapidgator.net": 1,
     "send.now": 1,
 }
+
+# Smart-download concurrency defaults (overridable via config.json).
+# - GLOBAL ceiling: hard cap on total simultaneous downloads (the "max download
+#   count"). Held only AFTER a per-host slot is acquired, so it bounds the total
+#   without ever letting one host's queue block another host.
+# - PER-HOST default: hosts not in SITE_DOWNLOAD_LIMITS each get their own queue
+#   of this size, instead of all sharing a single pool. This is what lets a
+#   small file on host B start while big files saturate host A.
+DEFAULT_MAX_CONCURRENT_DOWNLOADS = 8
+DEFAULT_MAX_PER_HOST_DOWNLOADS = 3
+# Sane bounds so a bad config value can't open unlimited sockets or stall everything.
+CONCURRENCY_MIN = 1
+CONCURRENCY_MAX = 32
+
+
+def _read_concurrency_limits() -> tuple:
+    """Read (global_ceiling, per_host_default) from config, clamped to sane bounds.
+
+    External/user data, so validate at the boundary and fall back to defaults on
+    anything non-numeric instead of letting a bad value break admission control.
+    """
+    cfg = get_config()
+
+    def _clamp(value, fallback):
+        try:
+            n = int(value)
+        except (TypeError, ValueError):
+            return fallback
+        return max(CONCURRENCY_MIN, min(CONCURRENCY_MAX, n))
+
+    global_ceiling = _clamp(cfg.get("max_concurrent_downloads"), DEFAULT_MAX_CONCURRENT_DOWNLOADS)
+    per_host_default = _clamp(cfg.get("max_per_host_downloads"), DEFAULT_MAX_PER_HOST_DOWNLOADS)
+    # Per-host can never exceed the global ceiling — that would be meaningless.
+    per_host_default = min(per_host_default, global_ceiling)
+    return global_ceiling, per_host_default
 
 # Wait limit for when the SSE callback pushes a message to the main loop's event queue.
 # Too long blocks the sync executor thread; too short drops SSE under heavy load.
@@ -239,11 +274,13 @@ class DownloadCore:
         # Concurrency limit for 1fichier local downloads (to work around the free-tier limit)
         self.MAX_FICHIER_LOCAL_DOWNLOADS = 1
         self.fichier_local_semaphore = asyncio.Semaphore(self.MAX_FICHIER_LOCAL_DOWNLOADS)
-        # Concurrency limit for proxy and general downloads
-        self.MAX_GENERAL_DOWNLOADS = 5
-        self.general_download_semaphore = asyncio.Semaphore(self.MAX_GENERAL_DOWNLOADS)
-        # Per-site semaphores (lazily created in the running loop), keyed by the
-        # SITE_DOWNLOAD_LIMITS host substring.
+        # Smart-download admission control. Every non-1fichier-local download
+        # acquires its per-host semaphore first (host isolation), then the global
+        # ceiling (total cap). Limits come from config so the user can tune them.
+        self.MAX_CONCURRENT_DOWNLOADS, self.MAX_PER_HOST_DOWNLOADS = _read_concurrency_limits()
+        self.total_download_semaphore = asyncio.Semaphore(self.MAX_CONCURRENT_DOWNLOADS)
+        # Per-host semaphores (lazily created in the running loop), keyed by the
+        # SITE_DOWNLOAD_LIMITS host substring or, for unlisted hosts, the hostname.
         self._site_semaphores: Dict[str, asyncio.Semaphore] = {}
         # For throttling SSE message frequency
         self.last_sse_time: Dict[int, float] = {}  # Last SSE send time per download
@@ -253,6 +290,36 @@ class DownloadCore:
         # A consecutive block streak lengthens the cooldown; a success resets it.
         self._fichier_cooldown_until: Optional[datetime.datetime] = None
         self._fichier_block_streak = 0
+
+    def refresh_concurrency_settings(self) -> None:
+        """Re-read concurrency limits from config and apply them to NEW downloads.
+
+        Called when settings are saved so changes take effect without a restart.
+        In-flight downloads keep the semaphore objects they already acquired, so
+        the new caps bind as those drain — total concurrency may briefly exceed a
+        lowered limit, then self-corrects. Per-host semaphores are rebuilt lazily.
+        """
+        self.MAX_CONCURRENT_DOWNLOADS, self.MAX_PER_HOST_DOWNLOADS = _read_concurrency_limits()
+        self.total_download_semaphore = asyncio.Semaphore(self.MAX_CONCURRENT_DOWNLOADS)
+        self._site_semaphores = {}
+        print(
+            f"[LOG] 동시 다운로드 설정 갱신 → 전체 {self.MAX_CONCURRENT_DOWNLOADS}개 / "
+            f"호스트당 {self.MAX_PER_HOST_DOWNLOADS}개"
+        )
+
+    def _resolve_host_limit(self, url: Optional[str]) -> tuple:
+        """Map a URL to its (host_key, per_host_max) for per-host admission.
+
+        Listed hosts (SITE_DOWNLOAD_LIMITS) keep their tuned limit and are keyed
+        by the matched substring; every other host is keyed by its hostname and
+        shares the default per-host cap. The key is what gives each host its own
+        semaphore, so one host's queue never blocks another's.
+        """
+        host = (urlparse(url or "").hostname or "").lower()
+        site_key = next((k for k in SITE_DOWNLOAD_LIMITS if k in host), None)
+        if site_key is not None:
+            return site_key, SITE_DOWNLOAD_LIMITS[site_key]
+        return (host or "_default"), self.MAX_PER_HOST_DOWNLOADS
 
     def should_send_sse(self, req_id: int, retry_count: int) -> bool:
         """Decide whether to send SSE (time + count based throttling)"""
@@ -591,57 +658,57 @@ class DownloadCore:
                     download_type = "일반"
                 print(f"[DEBUG] {download_type} 다운로드 시작: {req_id}")
 
-                # Pick the per-site semaphore so each host has its own queue
-                # (falls back to the shared general semaphore for unlisted hosts).
-                host = (urlparse(req.original_url or req.url or "").hostname or "").lower()
-                site_key = next((k for k in SITE_DOWNLOAD_LIMITS if k in host), None)
-                if site_key is not None:
-                    site_sem = self._site_semaphores.get(site_key)
-                    if site_sem is None:
-                        site_sem = asyncio.Semaphore(SITE_DOWNLOAD_LIMITS[site_key])
-                        self._site_semaphores[site_key] = site_sem
-                    download_semaphore = site_sem
-                    download_semaphore_max = SITE_DOWNLOAD_LIMITS[site_key]
-                else:
-                    download_semaphore = self.general_download_semaphore
-                    download_semaphore_max = self.MAX_GENERAL_DOWNLOADS
+                # Smart admission: every host gets its OWN queue, so several big
+                # files on one host never starve a small file on another host.
+                host_key, per_host_max = self._resolve_host_limit(req.original_url or req.url)
+                host_semaphore = self._site_semaphores.get(host_key)
+                if host_semaphore is None:
+                    host_semaphore = asyncio.Semaphore(per_host_max)
+                    self._site_semaphores[host_key] = host_semaphore
 
-                # Apply the per-site download concurrency limit
-                # Check whether to wait on the semaphore
-                if download_semaphore._value == 0:  # The semaphore is already in use
+                # If either the host queue or the global ceiling is full, mark the
+                # download pending so the UI shows it is waiting its turn.
+                if host_semaphore._value == 0 or self.total_download_semaphore._value == 0:
                     print(f"[DEBUG] {download_type} 다운로드 제한 도달, 순서 대기 중: {req_id}")
                     await self.send_download_update(req_id, {
                         "status": "pending",
-                        "message": f"다운로드 순서를 기다리는 중... (최대 {download_semaphore_max}개 동시 실행)"
+                        "message": (
+                            f"다운로드 순서를 기다리는 중... "
+                            f"(호스트당 {per_host_max}개 / 전체 {self.MAX_CONCURRENT_DOWNLOADS}개 동시 실행)"
+                        )
                     })
                     # Update the status in the DB
                     req.status = StatusEnum.pending
                     db.commit()
 
-                async with download_semaphore:
-                    print(f"[DEBUG] {download_type} 다운로드 세마포어 획득: {req_id}")
+                # Acquire the host slot FIRST, then the global ceiling. A task
+                # waiting on the global cap holds only its own host slot, so it can
+                # never block a different host from starting.
+                async with host_semaphore:
+                    async with self.total_download_semaphore:
+                        print(f"[DEBUG] {download_type} 다운로드 세마포어 획득: {req_id}")
 
-                    if skip_parsing:
-                        # File info is present, so skip parsing and start downloading immediately
-                        await self.send_download_update(req_id, {
-                            "status": "downloading",
-                            "message": f"{download_type} 다운로드 시작 중..."
-                        })
-                        req.status = StatusEnum.downloading
-                    else:
-                        # When parsing is required
-                        await self.send_download_update(req_id, {
-                            "status": "parsing",
-                            "message": f"대기 완료, {download_type} 다운로드 시작 중..."
-                        })
-                        req.status = StatusEnum.parsing
-                    db.commit()
+                        if skip_parsing:
+                            # File info is present, so skip parsing and start downloading immediately
+                            await self.send_download_update(req_id, {
+                                "status": "downloading",
+                                "message": f"{download_type} 다운로드 시작 중..."
+                            })
+                            req.status = StatusEnum.downloading
+                        else:
+                            # When parsing is required
+                            await self.send_download_update(req_id, {
+                                "status": "parsing",
+                                "message": f"대기 완료, {download_type} 다운로드 시작 중..."
+                            })
+                            req.status = StatusEnum.parsing
+                        db.commit()
 
-                    if is_1fichier:
-                        await self._download_with_proxy_async(req, db, skip_preparse=skip_parsing)  # 1fichier proxy download
-                    else:
-                        await self._download_local_async(req, db)  # Plain URL download
-                    print(f"[DEBUG] {download_type} 다운로드 세마포어 해제: {req_id}")
+                        if is_1fichier:
+                            await self._download_with_proxy_async(req, db, skip_preparse=skip_parsing)  # 1fichier proxy download
+                        else:
+                            await self._download_local_async(req, db)  # Plain URL download
+                        print(f"[DEBUG] {download_type} 다운로드 세마포어 해제: {req_id}")
 
         except asyncio.CancelledError:
             # Download cancelled
@@ -2254,7 +2321,7 @@ class DownloadCore:
             print(f"[DEBUG] 세마포어 해제 대기 완료, 자동 시작 체크")
 
             # Log the current semaphore state
-            print(f"[DEBUG] 현재 세마포어 상태 - 1fichier: {self.fichier_local_semaphore._value}, 일반: {self.general_download_semaphore._value}")
+            print(f"[DEBUG] 현재 세마포어 상태 - 1fichier: {self.fichier_local_semaphore._value}, 전체: {self.total_download_semaphore._value}")
 
             await self._start_next_pending_download()
         except Exception as e:

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -4,4 +4,4 @@ App version management
 """
 
 # Current app version
-CURRENT_VERSION = "v2.1.2"
+CURRENT_VERSION = "v2.2.0"

--- a/backend/locales/ar.json
+++ b/backend/locales/ar.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "لم يُعثر على الاسم",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/de.json
+++ b/backend/locales/de.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Name nicht gefunden",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/en.json
+++ b/backend/locales/en.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Name not found",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/es.json
+++ b/backend/locales/es.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Nombre no encontrado",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/fr.json
+++ b/backend/locales/fr.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Nom introuvable",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/id.json
+++ b/backend/locales/id.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Nama tidak ditemukan",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/it.json
+++ b/backend/locales/it.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Nome non trovato",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/ja.json
+++ b/backend/locales/ja.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "ファイル名不明",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "同時ダウンロード",
+  "max_concurrent_label": "最大同時ダウンロード数（全体）",
+  "max_concurrent_hint": "全ホスト合計の上限です。大きくするほど一度に多くの帯域を使います。",
+  "max_per_host_label": "ホストごとの最大ダウンロード数",
+  "max_per_host_hint": "あるホストの大きなファイルが別ホストの小さなファイルを待たせないよう、ホストごとに別キューを使います。",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/ko.json
+++ b/backend/locales/ko.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "파일명 확인 불가",
   "flaresolverr_url_label": "FlareSolverr 주소",
   "flaresolverr_url_hint": "Cloudflare 보호 호스트(MegaUp/GoFile 등)용. 비우면 기본값(localhost:8191)을 사용합니다.",
+  "concurrency_legend": "동시 다운로드",
+  "max_concurrent_label": "최대 동시 다운로드 (전체)",
+  "max_concurrent_hint": "모든 호스트를 합친 전체 상한입니다. 높일수록 한 번에 더 많은 대역폭을 사용합니다.",
+  "max_per_host_label": "호스트당 최대 다운로드",
+  "max_per_host_hint": "한 호스트의 큰 파일이 다른 호스트의 작은 파일을 굶기지 않도록 호스트마다 별도 큐를 둡니다.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/nl.json
+++ b/backend/locales/nl.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Naam niet gevonden",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/pl.json
+++ b/backend/locales/pl.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Nazwa nieznaleziona",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/pt-BR.json
+++ b/backend/locales/pt-BR.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Nome não encontrado",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/ru.json
+++ b/backend/locales/ru.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Имя не найдено",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/th.json
+++ b/backend/locales/th.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "ไม่พบชื่อไฟล์",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/tr.json
+++ b/backend/locales/tr.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Ad bulunamadı",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/vi.json
+++ b/backend/locales/vi.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "Không tìm thấy tên",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "Concurrent Downloads",
+  "max_concurrent_label": "Max concurrent downloads (total)",
+  "max_concurrent_hint": "Global ceiling across all hosts. Higher uses more bandwidth at once.",
+  "max_per_host_label": "Max downloads per host",
+  "max_per_host_hint": "Keeps big files on one host from starving small files on another. Each host gets its own queue.",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/zh-CN.json
+++ b/backend/locales/zh-CN.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "文件名未找到",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "并发下载",
+  "max_concurrent_label": "最大并发下载数（总计）",
+  "max_concurrent_hint": "所有主机的全局上限。数值越大，同时占用的带宽越多。",
+  "max_per_host_label": "每个主机的最大下载数",
+  "max_per_host_hint": "为每个主机设置独立队列，避免某主机的大文件拖慢另一主机的小文件。",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/locales/zh-TW.json
+++ b/backend/locales/zh-TW.json
@@ -433,5 +433,10 @@
   "file_name_unresolved": "找不到檔名",
   "flaresolverr_url_label": "FlareSolverr URL",
   "flaresolverr_url_hint": "For Cloudflare-protected hosts (MegaUp/GoFile, etc.). Leave empty to use the default (localhost:8191).",
+  "concurrency_legend": "並行下載",
+  "max_concurrent_label": "最大並行下載數（總計）",
+  "max_concurrent_hint": "所有主機的全域上限。數值越大，同時佔用的頻寬越多。",
+  "max_per_host_label": "每個主機的最大下載數",
+  "max_per_host_hint": "為每個主機設定獨立佇列，避免某主機的大檔案拖慢另一主機的小檔案。",
   "flaresolverr_url_placeholder": "http://flaresolverr:8191"
 }

--- a/backend/tests/test_smart_download_concurrency.py
+++ b/backend/tests/test_smart_download_concurrency.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Tests for smart-download admission control.
+
+The core guarantee: every host gets its OWN concurrency queue, so a few big
+files on one host can never starve a small file on a different host. Limits are
+read from config and clamped, and a global ceiling bounds total downloads.
+"""
+
+import asyncio
+
+import pytest
+
+from core import download_core as dc_module
+from core.download_core import DownloadCore, _read_concurrency_limits, SITE_DOWNLOAD_LIMITS
+
+
+def _write_config(values):
+    """Overwrite the (test-isolated) config.json with the given dict."""
+    import json
+    from core.config import CONFIG_FILE
+
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(values, f)
+
+
+def test_read_concurrency_limits_uses_defaults_when_unset():
+    _write_config({})
+    ceiling, per_host = _read_concurrency_limits()
+    assert ceiling == dc_module.DEFAULT_MAX_CONCURRENT_DOWNLOADS
+    assert per_host == dc_module.DEFAULT_MAX_PER_HOST_DOWNLOADS
+
+
+def test_read_concurrency_limits_clamps_out_of_range():
+    _write_config({"max_concurrent_downloads": 999, "max_per_host_downloads": 0})
+    ceiling, per_host = _read_concurrency_limits()
+    assert ceiling == dc_module.CONCURRENCY_MAX  # 999 -> 32
+    assert per_host == dc_module.CONCURRENCY_MIN  # 0 -> 1
+
+
+def test_read_concurrency_limits_falls_back_on_non_numeric():
+    _write_config({"max_concurrent_downloads": "lots", "max_per_host_downloads": None})
+    ceiling, per_host = _read_concurrency_limits()
+    assert ceiling == dc_module.DEFAULT_MAX_CONCURRENT_DOWNLOADS
+    assert per_host == dc_module.DEFAULT_MAX_PER_HOST_DOWNLOADS
+
+
+def test_per_host_never_exceeds_global_ceiling():
+    _write_config({"max_concurrent_downloads": 2, "max_per_host_downloads": 9})
+    ceiling, per_host = _read_concurrency_limits()
+    assert ceiling == 2
+    assert per_host == 2  # capped down to the ceiling
+
+
+def test_listed_host_uses_its_tuned_limit():
+    _write_config({})
+    dc = DownloadCore()
+    key, limit = dc._resolve_host_limit("https://gofile.io/d/abc123")
+    assert key == "gofile.io"
+    assert limit == SITE_DOWNLOAD_LIMITS["gofile.io"]
+
+
+def test_unlisted_host_uses_default_per_host_cap():
+    _write_config({})
+    dc = DownloadCore()
+    key, limit = dc._resolve_host_limit("https://some-random-host.example/file/9")
+    assert key == "some-random-host.example"
+    assert limit == dc.MAX_PER_HOST_DOWNLOADS
+
+
+def test_different_unlisted_hosts_get_distinct_keys():
+    """The whole point: host A and host B must not share a queue."""
+    _write_config({})
+    dc = DownloadCore()
+    key_a, _ = dc._resolve_host_limit("https://big-files.example/a")
+    key_b, _ = dc._resolve_host_limit("https://small-files.example/b")
+    assert key_a != key_b
+
+
+def test_missing_or_empty_url_falls_back_to_default_key():
+    _write_config({})
+    dc = DownloadCore()
+    assert dc._resolve_host_limit(None) == ("_default", dc.MAX_PER_HOST_DOWNLOADS)
+    assert dc._resolve_host_limit("") == ("_default", dc.MAX_PER_HOST_DOWNLOADS)
+
+
+def test_refresh_concurrency_settings_reapplies_config():
+    _write_config({"max_concurrent_downloads": 8, "max_per_host_downloads": 3})
+    dc = DownloadCore()
+    assert dc.MAX_CONCURRENT_DOWNLOADS == 8
+
+    _write_config({"max_concurrent_downloads": 4, "max_per_host_downloads": 2})
+    dc.refresh_concurrency_settings()
+    assert dc.MAX_CONCURRENT_DOWNLOADS == 4
+    assert dc.MAX_PER_HOST_DOWNLOADS == 2
+    assert dc.total_download_semaphore._value == 4
+    assert dc._site_semaphores == {}  # rebuilt lazily
+
+
+@pytest.mark.asyncio
+async def test_busy_host_does_not_block_a_different_host():
+    """Saturate host A's queue; a host-B download must still acquire its slot."""
+    _write_config({"max_concurrent_downloads": 8, "max_per_host_downloads": 2})
+    dc = DownloadCore()
+
+    key_a, limit_a = dc._resolve_host_limit("https://host-a.example/x")
+    sem_a = asyncio.Semaphore(limit_a)
+    dc._site_semaphores[key_a] = sem_a
+    # Fill host A completely.
+    for _ in range(limit_a):
+        await sem_a.acquire()
+    assert sem_a._value == 0
+
+    # Host B is independent — its slot is free.
+    key_b, limit_b = dc._resolve_host_limit("https://host-b.example/y")
+    sem_b = dc._site_semaphores.get(key_b) or asyncio.Semaphore(limit_b)
+    acquired = sem_b.locked() is False and sem_b._value > 0
+    assert acquired, "host B should not be blocked by a saturated host A"

--- a/frontend/src/lib/SettingsModal.svelte
+++ b/frontend/src/lib/SettingsModal.svelte
@@ -312,6 +312,8 @@
       fichier_email: currentSettings.fichier_email || "",
       fichier_password: currentSettings.fichier_password || "",
       flaresolverr_url: currentSettings.flaresolverr_url || "",
+      max_concurrent_downloads: currentSettings.max_concurrent_downloads ?? 8,
+      max_per_host_downloads: currentSettings.max_per_host_downloads ?? 3,
     };
     selectedTheme = settings.theme || $theme;
     originalTheme = $theme;
@@ -1172,6 +1174,31 @@
               bind:value={settings.flaresolverr_url}
             />
             <small class="input-hint">{$t("flaresolverr_url_hint")}</small>
+          </fieldset>
+
+          <fieldset class="form-group">
+            <legend>{$t("concurrency_legend")}</legend>
+            <label for="max-concurrent">{$t("max_concurrent_label")}</label>
+            <input
+              id="max-concurrent"
+              type="number"
+              min="1"
+              max="32"
+              class="input"
+              bind:value={settings.max_concurrent_downloads}
+            />
+            <small class="input-hint">{$t("max_concurrent_hint")}</small>
+
+            <label for="max-per-host">{$t("max_per_host_label")}</label>
+            <input
+              id="max-per-host"
+              type="number"
+              min="1"
+              max="32"
+              class="input"
+              bind:value={settings.max_per_host_downloads}
+            />
+            <small class="input-hint">{$t("max_per_host_hint")}</small>
           </fieldset>
 
           <fieldset class="form-group telegram-notifications">


### PR DESCRIPTION
## 문제
유저 지적: **큰 파일 여러 개가 한 호스트에 걸리면, 다른 호스트의 작은 파일이 굶는다.**

원인: listed 호스트(megaup/gofile/…)는 이미 호스트별 세마포어가 있지만, **unlisted 호스트는 전부 `general_download_semaphore=5` 하나를 공유**했음. 그래서 unlisted 큰 파일 5개가 슬롯을 다 잡으면 다른 unlisted 호스트의 작은 파일이 대기.

## 해결 — 호스트별 admission + 글로벌 상한
- **모든 호스트가 자기 큐를 가짐.** unlisted 호스트는 hostname 기준으로 각자 세마포어(기본 3). listed 호스트는 기존 튜닝값 유지.
- **글로벌 상한 세마포어**가 전체 동시 다운로드 수를 제한(= "최대 다운로드 개수").
- 획득 순서: **호스트 슬롯 먼저 → 글로벌 상한.** 글로벌을 기다리는 다운로드는 자기 호스트 슬롯만 들고 있으므로 **다른 호스트를 절대 막지 않음** ("비키면서" 병렬).
- per-host는 작고 글로벌은 넉넉 → 한 호스트가 큐를 독식 못 함.

## 설정 (자동 + 조정 가능)
- `config.json`에 `max_concurrent_downloads`(기본 8), `max_per_host_downloads`(기본 3) 추가. `[1, 32]`로 clamp, per-host는 글로벌 상한 이하로 보정.
- 설정 모달에 "동시 다운로드" 섹션(전체/호스트당 입력) 추가, 18개 로케일 키.
- 저장 시 `refresh_concurrency_settings()`로 **재시작 없이** 새 다운로드부터 적용(진행 중인 건 자연 배수).

## 테스트
- 신규 10개: 한도 읽기/clamp, per-host 격리(바쁜 호스트가 다른 호스트를 안 막음), live refresh.
- 백엔드 488 passed / locale parity 52 passed / 프론트 빌드 OK.

## 버전
`v2.1.2` → **`v2.2.0`** (auto-tag 릴리즈). 그동안 main에 쌓인 #30~#40도 함께 릴리즈로 묶임.