### PR TITLE
fix: HTML 페이지를 받아놓고 완료로 찍던 문제

### DIFF
--- a/backend/core/download_core.py
+++ b/backend/core/download_core.py
@@ -187,6 +187,49 @@ SPECIAL_HOSTER_PARSE_TIMEOUT_SEC = 300  # 5 minutes
 SPECIAL_NODE_RETRY_BACKOFF_SEC = (5, 15, 30)
 
 
+# 파일 대신 페이지를 받아놓고 완료 처리하면 안 된다.
+#
+# 호스터는 실패를 200 으로 돌려준다 — 캡차, Cloudflare 챌린지, 미러 선택
+# 페이지, "링크 만료" 안내가 전부 정상 응답으로 온다. 그걸 그대로 저장하고
+# done 으로 찍으면 사용자는 받은 줄 알고, 그 쓰레기가 압축 해제·라이브러리
+# 등록까지 그대로 흘러간다. 실측: multiup 미러 목록 HTML 57KB 가
+# "R-Type Tactics I-II Cosmos ....part2.rar" 이라는 이름으로 done 이 됐다.
+#
+# 예전에는 Content-Type 검사가 is_special_hoster_url() 로 게이팅돼 있어서
+# 등록되지 않은 호스터는 통째로 빠져나갔다. HTML 은 어느 호스터에서 오든
+# 파일이 아니므로 게이트 없이 본다.
+_HTML_SNIFF_MARKERS = (b"<!doctype", b"<html", b"<?xml", b"<head", b"<script")
+_HTML_SNIFF_BYTES = 1024
+
+
+def _looks_like_html(path: str) -> bool:
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(_HTML_SNIFF_BYTES)
+    except OSError:
+        return False
+    stripped = head.lstrip()[:256].lower()
+    return any(stripped.startswith(m) for m in _HTML_SNIFF_MARKERS)
+
+
+def assert_downloaded_a_real_file(req, downloaded_size: int, content_type: str = "") -> None:
+    """완료 처리 직전에 실제 파일을 받았는지 확인한다. 아니면 예외를 던져
+    실패 경로로 보낸다 — 실패는 실패로 남아야 재시도·미러 교체가 가능하다."""
+    if "text/html" in (content_type or "").lower():
+        raise Exception("호스팅 최종 링크가 파일 대신 HTML/보안 확인 페이지를 반환함")
+
+    path = getattr(req, "save_path", None)
+    if path and os.path.exists(path) and _looks_like_html(path):
+        raise Exception("받은 내용이 파일이 아니라 HTML 페이지입니다 (캡차/미러 목록/차단 페이지)")
+
+    # Content-Length 를 받았는데 그보다 적게 받았으면 끊긴 것이다.
+    total = getattr(req, "total_size", 0) or 0
+    if total > 0 and downloaded_size < total:
+        raise Exception(
+            f"전송이 중간에 끊겼습니다 ({downloaded_size}/{total} bytes)"
+        )
+
+
 def _clear_failure_metadata(req) -> None:
     """On a successful completion, wipe leftover failure flags so the row no
     longer carries a stale ``error`` / ``failure_kind`` / ``next_retry_at`` /
@@ -1558,6 +1601,12 @@ class DownloadCore:
         )
         print(f"[DEBUG] 파일 다운로드 완료 - 최종크기: {downloaded_size}")
 
+        # 완료로 찍기 전에 실제 파일인지 확인한다. .part 를 최종 이름으로
+        # 바꾸기 전에 봐야 쓰레기가 최종 이름을 차지하지 않는다.
+        assert_downloaded_a_real_file(
+            req, downloaded_size, response.headers.get("Content-Type") or ""
+        )
+
         # Rename .part → final file name
         final_path = get_final_file_path(req.save_path)
         if req.save_path != final_path:
@@ -1751,7 +1800,10 @@ class DownloadCore:
                             if response.status not in [200, 206]:
                                 raise Exception(f"HTTP {response.status}: {response.reason}")
                             content_type = (response.headers.get("Content-Type") or "").lower()
-                            if is_special_hoster_url(req.original_url or req.url) and "text/html" in content_type:
+                            # 호스터 등록 여부와 무관하게 본다. 예전에는
+                            # is_special_hoster_url() 로 게이팅돼 있어서 등록되지
+                            # 않은 호스터(multiup 등)의 HTML 이 파일로 저장됐다.
+                            if "text/html" in content_type:
                                 raise Exception(
                                     "호스팅 최종 링크가 파일 대신 HTML/보안 확인 페이지를 반환함"
                                 )
@@ -2057,6 +2109,12 @@ class DownloadCore:
                                     response, req.save_path, initial_size, req.total_size, req, db
                                 )
                                 print(f"[DEBUG] 파일 다운로드 완료 - 최종크기: {downloaded_size}")
+
+                                # 완료로 찍기 전에 실제 파일인지 확인한다.
+                                assert_downloaded_a_real_file(
+                                    req, downloaded_size,
+                                    response.headers.get("Content-Type") or "",
+                                )
 
                                 # Rename the .part file to the final file name
                                 final_path = get_final_file_path(req.save_path)

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -4,4 +4,4 @@ App version management
 """
 
 # Current app version
-CURRENT_VERSION = "v2.14.2"
+CURRENT_VERSION = "v2.14.3"

--- a/backend/tests/test_completion_guard.py
+++ b/backend/tests/test_completion_guard.py
@@ -1,0 +1,105 @@
+"""완료 처리 직전 검증 — 파일이 아닌 것을 done 으로 찍지 않는다.
+
+호스터는 실패를 200 으로 돌려준다. 캡차, Cloudflare 챌린지, 미러 선택
+페이지, 만료 안내가 전부 정상 응답으로 온다. 그걸 저장하고 done 으로
+찍으면 사용자는 받은 줄 알고, 그 쓰레기가 압축 해제와 라이브러리 등록까지
+그대로 흘러간다.
+
+실측 사고: multiup.io 미러 목록 HTML 57,523 바이트가
+"R-Type Tactics I-II Cosmos [01003A8019D74000][v0].part2.rar" 이름으로
+done 처리됐다. 원인은 Content-Type 검사가 is_special_hoster_url() 로
+게이팅돼 있어서 등록되지 않은 호스터가 통째로 빠져나간 것.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from core.download_core import assert_downloaded_a_real_file
+
+
+class _Req:
+    def __init__(self, save_path="", total_size=0):
+        self.save_path = save_path
+        self.total_size = total_size
+
+
+def _write(tmp_path, name, data: bytes):
+    p = os.path.join(tmp_path, name)
+    with open(p, "wb") as fh:
+        fh.write(data)
+    return p
+
+
+def test_html_content_type_은_어느_호스터든_실패(tmp_path):
+    # 예전에는 등록된 호스터일 때만 봤다. 이제 게이트가 없다.
+    req = _Req(save_path=str(tmp_path / "nope.rar"))
+    with pytest.raises(Exception, match="HTML/보안 확인 페이지"):
+        assert_downloaded_a_real_file(req, 57523, "text/html; charset=utf-8")
+
+
+def test_multiup_미러목록_페이지를_잡아낸다(tmp_path):
+    # 실제 사고 재현: Content-Type 이 없어도 내용으로 잡아야 한다.
+    body = (
+        b'<!doctype html>\n<html lang="fr" class="has-top-menu">\n<head>\n'
+        b"    <title>Telecharger ... - Upload mirroir - MultiUp.io</title>\n"
+    )
+    req = _Req(save_path=_write(str(tmp_path), "x.rar", body))
+    with pytest.raises(Exception, match="HTML 페이지"):
+        assert_downloaded_a_real_file(req, len(body), "")
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"<html><body>captcha</body></html>",
+        b"  \n  <!DOCTYPE HTML PUBLIC>",
+        b"<?xml version='1.0'?><error/>",
+        b"<head><meta http-equiv='refresh'></head>",
+        b"<script>window.location='/login'</script>",
+    ],
+)
+def test_각종_페이지_응답을_잡아낸다(tmp_path, body):
+    req = _Req(save_path=_write(str(tmp_path), "x.rar", body))
+    with pytest.raises(Exception):
+        assert_downloaded_a_real_file(req, len(body), "")
+
+
+def test_전송이_끊기면_실패(tmp_path):
+    # Content-Length 를 받았는데 그보다 적게 받았으면 완료가 아니다.
+    req = _Req(save_path=_write(str(tmp_path), "x.rar", b"Rar!\x1a\x07\x01\x00"), total_size=5_000_000_000)
+    with pytest.raises(Exception, match="중간에 끊"):
+        assert_downloaded_a_real_file(req, 1_234_567, "")
+
+
+def test_정상_rar_은_통과(tmp_path):
+    body = b"Rar!\x1a\x07\x01\x00" + b"\x00" * 512
+    req = _Req(save_path=_write(str(tmp_path), "ok.rar", body), total_size=len(body))
+    assert_downloaded_a_real_file(req, len(body), "application/octet-stream")
+
+
+def test_정상_nsp_은_통과(tmp_path):
+    body = b"PFS0" + b"\x00" * 4096
+    req = _Req(save_path=_write(str(tmp_path), "ok.nsp", body), total_size=len(body))
+    assert_downloaded_a_real_file(req, len(body), "binary/octet-stream")
+
+
+def test_총크기를_모르면_크기검사는_건너뛴다(tmp_path):
+    # Content-Length 를 안 주는 호스터가 있다. 그때까지 실패로 만들면 안 된다.
+    body = b"Rar!\x1a\x07\x01\x00"
+    req = _Req(save_path=_write(str(tmp_path), "ok.rar", body), total_size=0)
+    assert_downloaded_a_real_file(req, len(body), "")
+
+
+def test_파일이_없어도_예외로_죽지_않는다():
+    # 경로가 비어있거나 사라진 경우 — 검사 자체가 터지면 안 된다.
+    assert_downloaded_a_real_file(_Req(save_path=""), 100, "")
+    assert_downloaded_a_real_file(_Req(save_path="/nonexistent/x.rar"), 100, "")
+
+
+def test_HTML_이_본문_뒤쪽에_있으면_통과(tmp_path):
+    # 바이너리 안에 우연히 <html 이 들어있을 수 있다. 선두만 본다.
+    body = b"Rar!\x1a\x07\x01\x00" + b"\x00" * 300 + b"<html>not really</html>"
+    req = _Req(save_path=_write(str(tmp_path), "ok.rar", body), total_size=len(body))
+    assert_downloaded_a_real_file(req, len(body), "")


### PR DESCRIPTION
## 문제

호스터는 실패를 200 으로 돌려준다. 캡차, Cloudflare 챌린지, 미러 선택 페이지, 만료 안내가 전부 정상 응답으로 온다. 그 본문을 저장하고 `done` 으로 표시하면 **사용자는 받은 줄 알고**, 그 쓰레기가 압축 해제와 라이브러리 등록까지 그대로 흘러간다.

실측 사고:

```
multiup.io 미러 목록 HTML  57,523 bytes
  → "R-Type Tactics I-II Cosmos [01003A8019D74000][v0].part2.rar"  status=done
```

5GB 짜리 분할 rar 자리에 57KB HTML 이 앉았고, 상태가 완료라 **재시도도 미러 교체도 트리거되지 않았다.**

## 원인

**1. Content-Type 검사가 게이팅돼 있었다**

```python
if is_special_hoster_url(req.original_url or req.url) and "text/html" in content_type:
```

등록되지 않은 호스터(multiup 등)는 검사를 통째로 건너뛴다.

**2. 완료 직전에 받은 내용을 확인하지 않았다**

Content-Type 을 안 주거나 `octet-stream` 으로 주는 호스터는 1번으로도 못 막는다.

## 수정

`is_special_hoster_url` 게이트 제거 — HTML 은 어느 호스터에서 오든 파일이 아니다.

`assert_downloaded_a_real_file()` 을 추가해 완료 경로 **두 곳** 모두에서 `.part` 를 최종 이름으로 바꾸기 **전에** 검사한다. 쓰레기가 최종 이름을 차지하지 않는다.

| 검사 | 동작 |
|---|---|
| Content-Type 이 `text/html` | 실패 |
| 본문 선두가 HTML/XML | 실패 (선두 256바이트만 — 바이너리 중간의 `<html` 은 통과) |
| 받은 크기 < Content-Length | 전송 중단으로 실패 |

실패로 남겨야 재시도와 미러 교체가 동작한다.

## 검증

회귀 테스트 13개 추가 (실제 multiup 응답 본문으로 재현). 전체 **535개 통과**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)