### PR TITLE
fix: 파일 핸들이 바닥나 파싱이 실패하던 문제

### DIFF
--- a/backend/core/app_factory.py
+++ b/backend/core/app_factory.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import asyncio
 import os
+import resource
 import signal
 import sys
 import atexit
@@ -66,10 +67,37 @@ async def _shutdown_step(label: str, coro_fn, timeout: float = SHUTDOWN_TIMEOUT_
         print(f"[WARNING] {label} stop error: {e}")
 
 
+def raise_open_file_limit() -> None:
+    """열 수 있는 파일 수의 soft 한도를 hard 까지 올린다.
+
+    동시 다운로드마다 소켓·SSL·임시파일이 붙고 FlareSolverr/Playwright 가
+    거기에 더 얹는다. 기본 soft 1024 로는 큐가 조금만 커져도 바닥나서
+    ``[Errno 24] Too many open files`` 로 파싱이 실패한다 — 다운로드 자체가
+    아니라 파싱 단계에서 죽으므로 원인이 잘 안 보인다.
+
+    도커의 ``ulimits`` 만으로는 부족하다. 컨테이너 진입점이 ``su`` 로 사용자를
+    바꾸는데, PAM 이 그 시점에 soft 한도를 기본값으로 되돌린다. 그래서 앱이
+    직접 올린다. soft 를 hard 까지 올리는 건 권한 없이도 항상 허용된다.
+    """
+    try:
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (OSError, ValueError, AttributeError):
+        return
+    if soft >= hard:
+        return
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
+    except (OSError, ValueError):
+        print(f"[WARNING] 파일 핸들 한도를 올리지 못했습니다 (soft={soft}, hard={hard})")
+        return
+    print(f"[LOG] 파일 핸들 한도 {soft} → {hard}")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage the application lifecycle"""
     print("[LOG] *** 애플리케이션 시작 ***")
+    raise_open_file_limit()
 
     # Bound the asyncio default thread pool so concurrent hoster parses queue
     # instead of stampeding the CPU (see DEFAULT_PARSE_CONCURRENCY note above).

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -4,4 +4,4 @@ App version management
 """
 
 # Current app version
-CURRENT_VERSION = "v2.16.6"
+CURRENT_VERSION = "v2.16.7"


### PR DESCRIPTION
## 문제

동시 다운로드마다 소켓·SSL·임시파일이 붙고 FlareSolverr/Playwright 가 거기에 더 얹는다. 기본 soft 한도 **1024** 로는 큐가 조금만 커져도 바닥난다.

```
[파싱 실패] 원인을 자동으로 분류하지 못했습니다 ([Errno 24] Too many open files)
```

실측으로 25건 큐를 돌리다 Combat Forces 파싱이 이걸로 실패했고, 예전 AFL Evolution 2 의 `attempts_json` 에도 같은 흔적이 남아 있다.

증상이 헷갈리는 이유는 **다운로드가 아니라 파싱 단계에서 터지기** 때문이다. 로그에는 "캡차는 통과했으나 링크가 발급되지 않았습니다" 처럼 호스터 탓으로 보이게 나온다.

## 왜 compose 의 ulimits 로는 부족한가

진입점이 `su appuser -c ...` 로 사용자를 바꾸는데, **PAM 이 그 시점에 soft 한도를 기본값으로 되돌린다.**

```
컨테이너 셸        : ulimit -n = 65536
파이썬 프로세스    : soft 1024 / hard 65536   ← 되돌아감
```

## 수정

앱이 시작할 때(`lifespan`) 스스로 soft 를 hard 까지 올린다. 권한 없이도 항상 허용되는 조작이라 실행 방식과 무관하게 동작한다.

```
before: (1024, 524288)
[LOG] 파일 핸들 한도 1024 → 524288
after : (524288, 524288)
```

실패해도 경고만 남기고 기동은 계속한다.

## 검증

컨테이너에서 실제 상승 확인. 전체 **765개 통과**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)