### PR TITLE
fix: 윈도우 빌드에서 resource 임포트로 죽던 문제

### DIFF
--- a/backend/core/app_factory.py
+++ b/backend/core/app_factory.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
 import asyncio
 import os
-import resource
 import signal
 import sys
 import atexit
+
+# resource 는 유닉스 전용이다. standalone(윈도우 EXE) 빌드에서도 이 모듈이
+# 로드되므로 없으면 None 으로 두고 한도 조정을 건너뛴다. 규칙대로 임포트는
+# 최상단에 두되, 플랫폼 차이만 여기서 흡수한다.
+try:
+    import resource
+except ImportError:
+    resource = None
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, APIRouter, Request
@@ -79,6 +86,8 @@ def raise_open_file_limit() -> None:
     바꾸는데, PAM 이 그 시점에 soft 한도를 기본값으로 되돌린다. 그래서 앱이
     직접 올린다. soft 를 hard 까지 올리는 건 권한 없이도 항상 허용된다.
     """
+    if resource is None:          # 윈도우 — 이런 한도가 없다
+        return
     try:
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     except (OSError, ValueError, AttributeError):

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -4,4 +4,4 @@ App version management
 """
 
 # Current app version
-CURRENT_VERSION = "v2.16.7"
+CURRENT_VERSION = "v2.16.8"


### PR DESCRIPTION
## 문제

v2.16.7 에서 파일 핸들 한도를 올리려고 `import resource` 를 넣었는데, **이 모듈은 유닉스 전용**이다. 윈도우 EXE 빌드의 스모크 테스트가 수집 단계에서 통째로 깨졌다.

```
tests/test_executors.py → core.app_factory → import resource
ModuleNotFoundError: No module named 'resource'
```

Docker 이미지는 정상 빌드됐고 `Release (Windows EXE)` 워크플로만 실패했다.

## 수정

임포트를 최상단에 둔 채(프로젝트 규칙: 소스 중간 임포트 금지) `try/except ImportError` 로 감싸고, 없으면 `None` 으로 두어 한도 조정을 건너뛴다. 윈도우에는 이런 한도 개념이 없으므로 건너뛰는 것이 올바른 동작이다.

## 검증

- 리눅스: **765개 통과**, 깨졌던 `test_executors.py` 5개도 통과
- 리눅스 동작 유지 확인 — `1024 → 524288`
- `resource` 를 차단한 상태에서 임포트 단계 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)